### PR TITLE
Add PlatformIO config file

### DIFF
--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -1,0 +1,11 @@
+[platformio]
+src_dir = Src
+include_dir = Inc
+
+[env]
+platform = https://github.com/CommunityGD32Cores/platform-gd32.git
+platform_packages = framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
+
+[env:genericGD32F130C8]
+board = genericGD32F130C8
+framework = spl


### PR DESCRIPTION
Make it possible to build project using VSCode / [PlatformIO](https://platformio.org/) using [platform-gd32](https://github.com/CommunityGD32Cores/platform-gd32)

I've not yet made this work
```
	#define STRINGIZE_AUX(a) #a
	#define STRINGIZE(a) STRINGIZE_AUX(a)
	#define INCLUE_FILE(target,version) STRINGIZE(defines_2-target-version.h)

	#include INCLUE_FILE(TARGET , LAYOUT)	// "defines_2-target-version.h"
```

but it compiles and can be debugged hard coding a defines file e.g.:

```
#include "defines_2-1-20.h"
```

The motor and the LEDs are slower and the tone of the beeper is lower which maybe suggests there is a timing issue. I'll add a video later