### PR TITLE
Fix clock on PlatformIO build

### DIFF
--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -4,10 +4,12 @@ include_dir = Inc
 
 [env]
 platform = https://github.com/CommunityGD32Cores/platform-gd32.git
-platform_packages = framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
+platform_packages = framework-spl-gd32@https://github.com/hoverboardhavoc/gd32-pio-spl-package.git#hoverboardhavoc/add__PIO_DONT_SET_CLOCK_SOURCE__
 
 [env:genericGD32F130C8]
 board = genericGD32F130C8
 framework = spl
 build_flags = -D GD32F130
 			  -D TARGET=1
+			  -D __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2=72000000UL
+			  -D __PIO_DONT_SET_CLOCK_SOURCE__


### PR DESCRIPTION
The PlatformIO build was unintentionally running at the wrong clock source, causing motors to emit a metallic noise.

Use __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2 (as used by the Keil build)

This required a little change to gd32-pio-spl-package to add support for __PIO_DONT_SET_CLOCK_SOURCE__

See https://github.com/CommunityGD32Cores/gd32-pio-spl-package/pull/13