### PR TITLE
Add LED_ORANGE define for ClassyWalk (2-1-20.h)

### DIFF
--- a/HoverBoardGigaDevice/Inc/defines_2-1-20.h
+++ b/HoverBoardGigaDevice/Inc/defines_2-1-20.h
@@ -1,8 +1,9 @@
 #ifndef DEFINES_2_1_20_H
 #define DEFINES_2_1_20_H
 
-#define LED_RED PB4
 #define LED_GREEN PB3
+#define LED_ORANGE PA15
+#define LED_RED PB4
 #define UPPER_LED PB2
 #define LOWER_LED PB5
 


### PR DESCRIPTION
The ClassyWalk (2-1-20.h) does have an exposed PIN for the orange led even though not all boards come with the actual LED