### PR TITLE
Tidy bldc

### DIFF
--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -66,15 +66,10 @@
 // ################################################################################
 
 
-#define PWM_FREQ         		16000     // PWM frequency in Hz
-#define DEAD_TIME        		60        // PWM deadtime (60 = 1�s, measured by oscilloscope)
-
+#define BLDC_TIMER_PERIOD       (72000000u / 2u / PWM_FREQ) // = 2250
 #define DC_CUR_LIMIT     		15        // Motor DC current limit in amps
-
-static const uint32_t BLDC_TIMER_PERIOD = (72000000u / 2u / PWM_FREQ); // = 2250
-static const int32_t BLDC_TIMER_MEAN_VALUE = BLDC_TIMER_PERIOD / 2;   // = 1125
-#define BLDC_TIMER_MIN_VALUE 10
-static const uint32_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
+#define DEAD_TIME        		60        // PWM deadtime (60 = 1�s, measured by oscilloscope)
+#define PWM_FREQ         		16000     // PWM frequency in Hz
 
 // ################################################################################
 

--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -71,8 +71,10 @@
 
 #define DC_CUR_LIMIT     		15        // Motor DC current limit in amps
 
-
-//#define BLDC_WEAKENING		// some kind of field weaking added by HarleyBob for his gen2.2 firmware ?
+static const uint32_t BLDC_TIMER_PERIOD = (72000000u / 2u / PWM_FREQ); // = 2250
+static const int32_t BLDC_TIMER_MEAN_VALUE = BLDC_TIMER_PERIOD / 2;   // = 1125
+#define BLDC_TIMER_MIN_VALUE 10
+static const uint32_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
 
 // ################################################################################
 

--- a/HoverBoardGigaDevice/Src/bldc.c
+++ b/HoverBoardGigaDevice/Src/bldc.c
@@ -2,6 +2,11 @@
 #include "../Inc/defines.h"
 #include <stdio.h>
 
+// Internal constants
+static const int32_t BLDC_TIMER_MID_VALUE = BLDC_TIMER_PERIOD / 2;   // = 1125
+static const int32_t BLDC_TIMER_MIN_VALUE = 10;
+static const uint32_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
+
 // Global variables for voltage and current
 float batteryVoltage = BAT_CELLS * 3.6;
 float currentDC = 0.42;		// to see in serial log that pin is not defined
@@ -125,7 +130,7 @@ void SetEnable(FlagStatus setEnable)
 //----------------------------------------------------------------------------
 void SetPWM(int16_t setPwm)
 {
-	bldc_inputFilterPwm = CLAMP(1.125 * setPwm, -BLDC_TIMER_MEAN_VALUE, BLDC_TIMER_MEAN_VALUE); // thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
+	bldc_inputFilterPwm = CLAMP(1.125 * setPwm, -BLDC_TIMER_MID_VALUE, BLDC_TIMER_MID_VALUE); // thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
 }
 
 
@@ -235,9 +240,9 @@ void CalculateBLDC(void)
 	blockPWM(bldc_outputFilterPwm, pos, &y, &b, &g);
 
 	// Set PWM output (pwm_res/2 is the mean value, setvalue has to be between 10 and pwm_res-10)
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, CLAMP(g + BLDC_TIMER_MEAN_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, CLAMP(b + BLDC_TIMER_MEAN_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, CLAMP(y + BLDC_TIMER_MEAN_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, CLAMP(g + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, CLAMP(b + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, CLAMP(y + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
 
 	// robo23
 	iOdom = iOdom - up_or_down(lastPos, pos); // int32 will overflow at +-2.147.483.648

--- a/HoverBoardGigaDevice/Src/setup.c
+++ b/HoverBoardGigaDevice/Src/setup.c
@@ -258,11 +258,11 @@ void PWM_init(void)
 	timer_deinit(TIMER_BLDC);
 	
 	// Set up the basic parameter struct for the timer
-	timerBldc_paramter_struct.counterdirection 	= TIMER_COUNTER_UP;
-	timerBldc_paramter_struct.prescaler 				= 0;
-	timerBldc_paramter_struct.alignedmode 			= TIMER_COUNTER_CENTER_DOWN;
-	timerBldc_paramter_struct.period                = BLDC_TIMER_PERIOD;
-	timerBldc_paramter_struct.clockdivision 		= TIMER_CKDIV_DIV1;
+	timerBldc_paramter_struct.counterdirection = TIMER_COUNTER_UP;
+	timerBldc_paramter_struct.prescaler = 0;
+	timerBldc_paramter_struct.alignedmode = TIMER_COUNTER_CENTER_DOWN;
+	timerBldc_paramter_struct.period = BLDC_TIMER_PERIOD;
+	timerBldc_paramter_struct.clockdivision = TIMER_CKDIV_DIV1;
 
 	timerBldc_paramter_struct.repetitioncounter = 0;
 	timer_auto_reload_shadow_disable(TIMER_BLDC);

--- a/HoverBoardGigaDevice/Src/setup.c
+++ b/HoverBoardGigaDevice/Src/setup.c
@@ -261,8 +261,9 @@ void PWM_init(void)
 	timerBldc_paramter_struct.counterdirection 	= TIMER_COUNTER_UP;
 	timerBldc_paramter_struct.prescaler 				= 0;
 	timerBldc_paramter_struct.alignedmode 			= TIMER_COUNTER_CENTER_DOWN;
-	timerBldc_paramter_struct.period						= 72000000 / 2 / PWM_FREQ;
+	timerBldc_paramter_struct.period                = BLDC_TIMER_PERIOD;
 	timerBldc_paramter_struct.clockdivision 		= TIMER_CKDIV_DIV1;
+
 	timerBldc_paramter_struct.repetitioncounter = 0;
 	timer_auto_reload_shadow_disable(TIMER_BLDC);
 	


### PR DESCRIPTION
I made some changes while trying to understand how the bldc works

The following constants, which are duplicated throughout the code, are now defined in `config.h`:

```
static const uint32_t BLDC_TIMER_PERIOD = (72000000u / 2u / PWM_FREQ); // = 2250
static const int32_t BLDC_TIMER_MEAN_VALUE = BLDC_TIMER_PERIOD / 2;   // = 1125
#define BLDC_TIMER_MIN_VALUE 10
static const uint32_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
```

I removed `BLDC_WEAKENING`. I could not make it work, the motors just jammed and the comment about it did not inspire confidence `(// some kind of field weaking added by HarleyBob for his gen2.2 firmware ?)`

