### PR TITLE
Field weakening experiment

### DIFF
--- a/HoverBoardGigaDevice/.gitignore
+++ b/HoverBoardGigaDevice/.gitignore
@@ -3,3 +3,6 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+Tests/build/
+/build
+.DS_Store

--- a/HoverBoardGigaDevice/Inc/commutation.h
+++ b/HoverBoardGigaDevice/Inc/commutation.h
@@ -1,0 +1,77 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COMMUTATION_H
+#define COMMUTATION_H
+
+#include <stdint.h>
+
+#include "config.h" // Neded for tests
+
+static const uint16_t BLDC_TIMER_MIN_VALUE = 10;
+static const uint16_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
+/**
+ * Max duty cycle is set to 1125 because of legacy implementation details in blockCommutation.c
+ */
+static const uint16_t DUTY_CYCLE_100_PERCENT = BLDC_TIMER_PERIOD / 2;   // = 1125
+
+/**
+ * @brief Determines the commutation sector based on Hall sensor inputs.
+ *
+ * This function interprets the states of the three Hall sensors and returns
+ * the corresponding commutation sector for BLDC motor control.
+ * Different papers and videos use different sector numbering conventions so we delegate this decision to the implementation.
+ * The convention for the sector numbering must be compatible with the get_pwm implementation.
+ * 
+ * @param hall_a State of Hall sensor A (0 or 1).
+ * @param hall_b State of Hall sensor B (0 or 1).
+ * @param hall_c State of Hall sensor C (0 or 1).
+ * @return Sector number (1-6) corresponding to the Hall sensor pattern.
+ */
+uint8_t get_sector(uint8_t hall_a, uint8_t hall_b, uint8_t hall_c);
+
+/**
+ * @brief Calculates PWM pulse values for each phase based on duty cycle and sector.
+ *
+ * This function computes the PWM pulse widths for phases A, B, and C, given the
+ * desired duty cycle and commutation sector. The results are written to the
+ * provided pointers.
+ *
+ * @param dutyCycle Desired PWM duty cycle (a value between -1125 and 1125 (DUTY_CYCLE_100_PERCENT) for legacy reasons).
+ * @param sector    Current commutation sector provided by get_sector().
+ * @param pulse_a   Pointer to store calculated PWM value for phase A.
+ * @param pulse_b   Pointer to store calculated PWM value for phase B.
+ * @param pulse_c   Pointer to store calculated PWM value for phase C.
+ */
+void get_pwm(int dutyCycle, uint8_t sector, uint32_t *pulse_a, uint32_t *pulse_b, uint32_t *pulse_c);
+
+#endif

--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -111,5 +111,18 @@
 // ###### ARMCHAIR ######
 #define FILTER_SHIFT 12 						// Low-pass filter for pwm, rank k=12
 
+#define BLOCK_COMMUTATION 0
+#define SVM_COMMUTATION 1
+
+// We need the #ifndef for the tests
+#ifndef COMMUTATION_MODE
+	#define COMMUTATION_MODE BLOCK_COMMUTATION
+#endif
+
+#if COMMUTATION_MODE == SVM_COMMUTATION
+	#ifndef PHASE_ADVANCE_AT_MAX_PWM_DEGREES // Also set from tests
+		#define PHASE_ADVANCE_AT_MAX_PWM_DEGREES 6
+	#endif
+#endif 
 
 #endif

--- a/HoverBoardGigaDevice/Inc/defines.h
+++ b/HoverBoardGigaDevice/Inc/defines.h
@@ -5,6 +5,7 @@
 #include "../Inc/setup.h"
 #include "../Inc/config.h"
 #include "../Inc/remote.h"
+#include "../Inc/mathdefines.h"
 
 
 #if defined(REMOTE_AUTODETECT)
@@ -130,15 +131,6 @@
 #ifndef ADC_BATTERY_VOLT
 	#define ADC_BATTERY_VOLT      0.024169921875  	// V_Batt to V_BattMeasure = factor 30: ( (ADC-Data/4095) *3,3V *30 )
 #endif
-
-
-// Useful math function defines
-#define ABS(a) (((a) < 0.0) ? -(a) : (a))
-#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-#ifndef MAX
-	#define MAX(x, high) (((x) > (high)) ? (high) : (x))
-#endif	
-#define MAP(x, xMin, xMax, yMin, yMax) ((x - xMin) * (yMax - yMin) / (xMax - xMin) + yMin)
 
 // ################################################################################
 

--- a/HoverBoardGigaDevice/Inc/mathDefines.h
+++ b/HoverBoardGigaDevice/Inc/mathDefines.h
@@ -1,0 +1,45 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef MATHDEFINES_H
+#define MATHDEFINES_H
+
+// Useful math function defines
+// Used from tests without including the gd headers
+
+#define ABS(a) (((a) < 0.0) ? -(a) : (a))
+#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
+#ifndef MAX
+	#define MAX(x, high) (((x) > (high)) ? (high) : (x))
+#endif	
+#define MAP(x, xMin, xMax, yMin, yMax) ((x - xMin) * (yMax - yMin) / (xMax - xMin) + yMin)
+
+#endif

--- a/HoverBoardGigaDevice/Src/bldc.c
+++ b/HoverBoardGigaDevice/Src/bldc.c
@@ -1,11 +1,50 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include "../Inc/defines.h"
 #include <stdio.h>
 
 // Internal constants
+static const uint8_t HALL_A_MASK = 0x4;
+static const uint8_t HALL_B_MASK = 0x2;
+static const uint8_t HALL_C_MASK = 0x1;
+
 static const int16_t BLDC_TIMER_MID_VALUE = BLDC_TIMER_PERIOD / 2;   // = 1125
 static const int16_t BLDC_TIMER_MIN_VALUE = 10;
 static const uint16_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
+static const uint16_t PHASE_ADVANCE_AT_MAX_PWM = 6;
+static const int16_t sine_q15[61] = {
+       0, 572, 1144, 1715, 2286, 2856, 3425, 3993, 4560, 5126, 5690, 6252, 6813, 7371, 7927, 8481, 9032, 9580, 10126, 10668, 11207, 11743, 12275, 12803, 13328, 13848, 14365, 14876, 15384, 15886, 16384, 16877, 17364, 17847, 18324, 18795, 19261, 19720, 20174, 20622, 21063, 21498, 21926, 22348, 22763, 23170, 23571, 23965, 24351, 24730, 25102, 25466, 25822, 26170, 26510, 26842, 27166, 27482, 27789, 28088, 28378
+};
 
 // Global variables for voltage and current
 float batteryVoltage = BAT_CELLS * 3.6;
@@ -23,9 +62,6 @@ FlagStatus bldc_enable = RESET;
 adc_buf_t adc_buffer;
 
 // Internal calculation variables
-uint8_t hall_a;
-uint8_t hall_b;
-uint8_t hall_c;
 uint8_t hall;
 uint8_t pos;
 uint8_t lastPos;
@@ -55,66 +91,96 @@ int16_t up_or_down(int16_t vorher, int16_t nachher)
   return up_down[modulo(vorher-nachher, 6)];
 }
 
-// Commutation table
-const uint8_t hall_to_pos[8] =
-{
-	// annotation: for example SA=0 means hall sensor pulls SA down to Ground
-  0, // hall position [-] - No function (access from 1-6) 
-  3, // hall position [1] (SA=1, SB=0, SC=0) -> PWM-position 3
-  5, // hall position [2] (SA=0, SB=1, SC=0) -> PWM-position 5
-  4, // hall position [3] (SA=1, SB=1, SC=0) -> PWM-position 4
-  1, // hall position [4] (SA=0, SB=0, SC=1) -> PWM-position 1
-  2, // hall position [5] (SA=1, SB=0, SC=1) -> PWM-position 2
-  6, // hall position [6] (SA=0, SB=1, SC=1) -> PWM-position 6
-  0, // hall position [-] - No function (access from 1-6) 
-};
 
-//----------------------------------------------------------------------------
-// Block PWM calculation based on position
-//----------------------------------------------------------------------------
-#ifndef PLATFORMIO
-__INLINE 
-#endif
-void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)		// robo 2024/09/04: remove __INLINE for PlatformIO
+__INLINE uint8_t getHall()
 {
-  switch(pwmPos)
+    // Read hall sensors
+    uint8_t hall_a = digitalRead(HALL_A);
+    uint8_t hall_b = digitalRead(HALL_B);
+    uint8_t hall_c = digitalRead(HALL_C);
+    return hall_a * HALL_A_MASK + hall_b * HALL_B_MASK + hall_c * HALL_C_MASK;
+}
+
+// Uses Jantzen Lee convention https://www.youtube.com/watch?v=XCzfHDnt6G4
+__INLINE uint8_t getPosition(uint8_t hall)
+{
+	switch (hall)
 	{
+		case 0b100:
+			return 0;
+		case 0b101:
+			return 1;
+		case 0b001:
+			return 2;
+		case 0b011:
+			return 3;
+		case 0b010:
+			return 4;
+		case 0b110:
+			return 5;
+		default:
+			return 0; // Not sure what a good convention for invalid state is.  Maybe the MCU should panic?
+					  // If we're field weakning, crashes can cause back EMF that blows stuff up. // https://www.youtube.com/watch?v=5eQyoVMz1dY
+	}
+}
+
+__INLINE void svmPWM(int sector, int t0, int t1, int t2,
+            uint32_t *phaseA, uint32_t *phaseB, uint32_t *phaseC)
+{
+    // exact integer half of the zero vector time
+    uint32_t h = (uint32_t)t0 >> 1;
+
+    switch (sector)
+    {
+    case 0:
+        *phaseA = h + (uint32_t)t2;
+        *phaseB = h;
+        *phaseC = h + (uint32_t)t1 + (uint32_t)t2;
+        break;
     case 1:
-      *y = 0;
-      *b = pwm;
-      *g = -pwm;
-      break;
+        *phaseA = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseB = h;
+        *phaseC = h + (uint32_t)t1;
+        break;
     case 2:
-      *y = -pwm;
-      *b = pwm;
-      *g = 0;
-      break;
+        *phaseA = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseB = h + (uint32_t)t2;
+        *phaseC = h;
+        break;
     case 3:
-      *y = -pwm;
-      *b = 0;
-      *g = pwm;
-      break;
+        *phaseA = h + (uint32_t)t1;
+        *phaseB = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseC = h;
+        break;
     case 4:
-      *y = 0;
-      *b = -pwm
-		;
-      *g = pwm;
-      break;
+        *phaseA = h;
+        *phaseB = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseC = h + (uint32_t)t2;
+        break;
     case 5:
-      *y = pwm;
-      *b = -pwm;
-      *g = 0;
-      break;
-    case 6:
-      *y = pwm;
-      *b = 0;
-      *g = -pwm;
-      break;
+        *phaseA = h;
+        *phaseB = h + (uint32_t)t2;
+        *phaseC = h + (uint32_t)t1 + (uint32_t)t2;
+        break;
     default:
-      *y = 0;
-      *b = 0;
-      *g = 0;
-  }
+        // fault condition: all off
+        *phaseA = 0;
+        *phaseB = 0;
+        *phaseC = 0;
+        break;
+    }
+}
+
+
+__INLINE int32_t calculateT(int16_t angle) {
+	// This needs some work
+	int16_t sine = sine_q15[angle];
+	int32_t tmp = bldc_outputFilterPwm;
+	int32_t tmp2 = tmp * sine;
+	int32_t tmp3 = tmp2 >> 15;
+	int32_t tmp4 = tmp3 * BLDC_TIMER_MAX_VALUE;
+	int32_t tmp5 = tmp4 / 1000;
+	return tmp5;
 }
 
 //----------------------------------------------------------------------------
@@ -130,22 +196,19 @@ void SetEnable(FlagStatus setEnable)
 //----------------------------------------------------------------------------
 void SetPWM(int16_t setPwm)
 {
-	//bldc_inputFilterPwm = CLAMP(1.125 * setPwm, -BLDC_TIMER_MID_VALUE, BLDC_TIMER_MID_VALUE); // thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
-	
-	bldc_inputFilterPwm =  BLDC_TIMER_MID_VALUE*(setPwm/1000.0);	// thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
-	bldc_inputFilterPwm =  CLAMP(bldc_inputFilterPwm ,-BLDC_TIMER_MID_VALUE, BLDC_TIMER_MID_VALUE); 	
+	bldc_inputFilterPwm = CLAMP(setPwm, -1000, 1000);
 }
 
 
 extern uint32_t steerCounter;								// Steer counter for setting update rate
 
+
 // Calculation-Routine for BLDC => calculates with 16kHz
 void CalculateBLDC(void)
 {
-	int y = 0;     // yellow = phase A
-	int b = 0;     // blue   = phase B
-	int g = 0;     // green  = phase C
-
+	uint32_t pulseA;
+	uint32_t pulseB;
+	uint32_t pulseC;
 	
 	#ifdef CURRENT_DC
 		// Calibrate ADC offsets for the first 1000 cycles
@@ -202,28 +265,25 @@ void CalculateBLDC(void)
 	//if (timedOut == SET)	DEBUG_LedSet((steerCounter%2) < 1,0)		
 	
 	// Read hall sensors
-	hall_a = digitalRead(HALL_A);
-	hall_b = digitalRead(HALL_B);
-	hall_c = digitalRead(HALL_C);
-	hall = hall_a * 1 + hall_b * 2 + hall_c * 4;
 
+    hall = getHall();
 
 	#ifdef TEST_HALL2LED
 		#ifdef LED_ORANGE
-			digitalWrite(LED_ORANGE,hall_b);
+			digitalWrite(LED_ORANGE, hall & HALL_B_MASK);
 		#elif defined(UPPER_LED)
-			digitalWrite(UPPER_LED,hall_b);
+			digitalWrite(UPPER_LED, hall & HALL_B_MASK);
 		#elif defined(LOWER_LED)
-			digitalWrite(LOWER_LED,hall_b);
+			digitalWrite(LOWER_LED, hall & HALL_B_MASK);
 		#else
-			if (hall_b)
+			if (hall & HALL_B_MASK)
 			{
 				digitalWrite(LED_GREEN,(steerCounter%2) < 1);
 				digitalWrite(LED_RED,(steerCounter%2) < 1);
 			}
 		#endif
-		digitalWrite(LED_GREEN,hall_a);
-		digitalWrite(LED_RED,hall_c);
+		digitalWrite(LED_GREEN, hall & HALL_A_MASK);
+		digitalWrite(LED_RED, hall & HALL_C_MASK);
 	#endif
 
 	// Determine current position based on hall sensors
@@ -231,7 +291,7 @@ void CalculateBLDC(void)
 		pos = AutodetectBldc(hall_to_pos[hall],buzzerTimer);
 		AutodetectScan(buzzerTimer);
 	#else
-		pos = hall_to_pos[hall];
+		pos = getPosition(hall);
 	#endif
 	
 		
@@ -239,14 +299,19 @@ void CalculateBLDC(void)
 	filter_reg = filter_reg - (filter_reg >> FILTER_SHIFT) + bldc_inputFilterPwm;
 	bldc_outputFilterPwm = filter_reg >> FILTER_SHIFT;
 
-	// Update PWM channels based on position y(ellow), b(lue), g(reen)
-	blockPWM(bldc_outputFilterPwm, pos, &y, &b, &g);
+	int angle = 30 + bldc_outputFilterPwm * PHASE_ADVANCE_AT_MAX_PWM / 1000;
+	// This is based on Jantzen Lee's equations https://youtu.be/oHEVdXucSJs?t=510
+	// ChatGPT thinks that I need to divide by a sine term.
+	int32_t t1 = calculateT(60 - angle);
+	int32_t t2 = calculateT(angle);
+	int32_t t0 = BLDC_TIMER_MAX_VALUE - t1 - t2;
+
+	svmPWM(pos, t0, t1, t2, &pulseA, &pulseB, &pulseC);
 
 	// Set PWM output (pwm_res/2 is the mean value, setvalue has to be between 10 and pwm_res-10)
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, CLAMP(g + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, CLAMP(b + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, CLAMP(y + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, CLAMP(pulseA, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, CLAMP(pulseB, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, CLAMP(pulseC, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
 	// robo23
 	iOdom = iOdom - up_or_down(lastPos, pos); // int32 will overflow at +-2.147.483.648
 	
@@ -262,6 +327,6 @@ void CalculateBLDC(void)
 	}
 	else if (speedCounter >= 4000)	realSpeed = 0;
 	
-	// Safe last position
+	// Save last position
 	lastPos = pos;
 }

--- a/HoverBoardGigaDevice/Src/blockCommutation.c
+++ b/HoverBoardGigaDevice/Src/blockCommutation.c
@@ -1,0 +1,124 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#if COMMUTATION_MODE == BLOCK_COMMUTATION
+
+#include <stdio.h>
+
+
+#include "commutation.h"
+#include "mathDefines.h"
+
+// Internal constants
+static const int16_t BLDC_TIMER_MID_VALUE = BLDC_TIMER_PERIOD / 2; // = 1125
+
+// Commutation table
+const uint8_t hall_to_pos[8] =
+    {
+        // annotation: for example SA=0 means hall sensor pulls SA down to Ground
+        0, // hall position [-] - No function (access from 1-6)
+        3, // hall position [1] (SA=1, SB=0, SC=0) -> PWM-position 3
+        5, // hall position [2] (SA=0, SB=1, SC=0) -> PWM-position 5
+        4, // hall position [3] (SA=1, SB=1, SC=0) -> PWM-position 4
+        1, // hall position [4] (SA=0, SB=0, SC=1) -> PWM-position 1
+        2, // hall position [5] (SA=1, SB=0, SC=1) -> PWM-position 2
+        6, // hall position [6] (SA=0, SB=1, SC=1) -> PWM-position 6
+        0, // hall position [-] - No function (access from 1-6)
+    };
+
+//----------------------------------------------------------------------------
+// Block PWM calculation based on position
+//----------------------------------------------------------------------------
+void blockPWM(int pwm, int pwmPos, int *a, int *b, int *c)		// robo 2024/09/04: remove __INLINE for PlatformIO
+{
+  switch(pwmPos)
+	{
+    case 1:
+      *b = 0;
+      *a = pwm;
+      *c = -pwm;
+      break;
+    case 2:
+      *b = -pwm;
+      *a = pwm;
+      *c = 0;
+      break;
+    case 3:
+      *b = -pwm;
+      *a = 0;
+      *c = pwm;
+      break;
+    case 4:
+      *b = 0;
+      *a = -pwm;
+      *c = pwm;
+      break;
+    case 5:
+      *b = pwm;
+      *a = -pwm;
+      *c = 0;
+      break;
+    case 6:
+      *b = pwm;
+      *a = 0;
+      *c = -pwm;
+      break;
+    default:
+      *b = 0;
+      *a = 0;
+      *c = 0;
+  }
+}
+
+uint8_t get_sector(uint8_t hall_a, uint8_t hall_b, uint8_t hall_c)
+{
+  uint8_t hall = hall_a * 1 + hall_b * 2 + hall_c * 4;
+  return hall_to_pos[hall];
+}
+
+void get_pwm(int pwm, uint8_t sector, uint32_t *pulse_a, uint32_t *pulse_b, uint32_t *pulse_c)
+{
+  int phaseA = 0; // yellow
+  int phaseB = 0; // blue
+  int phaseC = 0; // green
+
+  // Update PWM channels based on position y(ellow), b(lue), g(reen)
+  blockPWM(pwm, sector, &phaseA, &phaseB, &phaseC);
+  // Set PWM output (pwm_res/2 is the mean value, setvalue has to be between 10 and pwm_res-10)
+  *pulse_a = CLAMP(phaseA + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+  *pulse_b = CLAMP(phaseB + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+  *pulse_c = CLAMP(phaseC + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+}
+
+#endif // COMMUTATION_MODE == BLOCK

--- a/HoverBoardGigaDevice/Src/svmCommutation.c
+++ b/HoverBoardGigaDevice/Src/svmCommutation.c
@@ -1,0 +1,147 @@
+#include "config.h"
+
+#if COMMUTATION_MODE == SVM_COMMUTATION
+
+#include <stdio.h>
+
+#include "commutation.h"
+#include "mathDefines.h"
+
+static const uint8_t HALL_A_MASK = 0x4;
+static const uint8_t HALL_B_MASK = 0x2;
+static const uint8_t HALL_C_MASK = 0x1;
+
+static const int16_t sine_q15[61] = {
+       0, 572, 1144, 1715, 2286, 2856, 3425, 3993, 4560, 5126, 5690, 6252, 6813, 7371, 7927, 8481, 9032, 9580, 10126, 10668, 11207, 11743, 12275, 12803, 13328, 13848, 14365, 14876, 15384, 15886, 16384, 16877, 17364, 17847, 18324, 18795, 19261, 19720, 20174, 20622, 21063, 21498, 21926, 22348, 22763, 23170, 23571, 23965, 24351, 24730, 25102, 25466, 25822, 26170, 26510, 26842, 27166, 27482, 27789, 28088, 28378
+};
+
+// Uses Jantzen Lee convention https://www.youtube.com/watch?v=XCzfHDnt6G4
+uint8_t getPosition(uint8_t hall)
+{
+	switch (hall)
+	{
+		case 0b100:
+			return 0;
+		case 0b101:
+			return 1;
+		case 0b001:
+			return 2;
+		case 0b011:
+			return 3;
+		case 0b010:
+			return 4;
+		case 0b110:
+			return 5;
+		default:
+			return 0; // Not sure what a good convention for invalid state is.  Maybe the MCU should panic?
+					  // If we're field weakning, crashes can cause back EMF that blows stuff up. // https://www.youtube.com/watch?v=5eQyoVMz1dY
+	}
+}
+
+void svmPWM(int sector, int t0, int t1, int t2,
+            uint32_t *phaseA, uint32_t *phaseB, uint32_t *phaseC)
+{
+    // exact integer half of the zero vector time
+    uint32_t h = (uint32_t)t0 >> 1;
+
+    switch (sector)
+    {
+    case 0:
+        *phaseA = h + (uint32_t)t2;
+        *phaseB = h;
+        *phaseC = h + (uint32_t)t1 + (uint32_t)t2;
+        break;
+    case 1:
+        *phaseA = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseB = h;
+        *phaseC = h + (uint32_t)t1;
+        break;
+    case 2:
+        *phaseA = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseB = h + (uint32_t)t2;
+        *phaseC = h;
+        break;
+    case 3:
+        *phaseA = h + (uint32_t)t1;
+        *phaseB = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseC = h;
+        break;
+    case 4:
+        *phaseA = h;
+        *phaseB = h + (uint32_t)t1 + (uint32_t)t2;
+        *phaseC = h + (uint32_t)t2;
+        break;
+    case 5:
+        *phaseA = h;
+        *phaseB = h + (uint32_t)t2;
+        *phaseC = h + (uint32_t)t1 + (uint32_t)t2;
+        break;
+    default:
+        // fault condition: all off
+        *phaseA = 0;
+        *phaseB = 0;
+        *phaseC = 0;
+        break;
+    }
+}
+
+
+int32_t calculateT(int16_t angle, int16_t modIndexPermille) {
+    // 1) clamp inputs
+    if (angle < 0)      angle = 0;
+    if (angle > 61)     angle = 61;
+
+    // 2) convert –DUTY_CYCLE_100_PERCENT…+DUTY_CYCLE_100_PERCENT → Q15 (–1.0…+1.0)
+    //    scale by 32767, add ±500 for rounding, then divide by DUTY_CYCLE_100_PERCENT
+    int32_t M_Q15 = (int32_t)modIndexPermille * 32767;
+    M_Q15 += (modIndexPermille >= 0 ?  500 : -500);
+    M_Q15 /= DUTY_CYCLE_100_PERCENT;                     // now in Q15
+
+    // 3) look up sin(angle) in Q15
+    int32_t s_Q15 = sine_q15[angle];
+
+    // 4) prod = M_Q15 * s_Q15 → Q30
+    int64_t prod30 = (int64_t)M_Q15 * s_Q15;
+
+    // 5) divide out sin(60°) (Q15): Q30 / Q15 → Q15
+    const int32_t sin60_Q15 = sine_q15[60];
+    // add half for rounding
+    int32_t t_Q15 = (int32_t)((prod30 + (sin60_Q15 >> 1)) / sin60_Q15);
+
+    // 6) scale Q15 → ticks: (Q15 * PERIOD) >> 15, with rounding
+    int64_t scaled = (int64_t)t_Q15 * BLDC_TIMER_PERIOD;
+    int32_t ticks  = (int32_t)((scaled + (1LL << 14)) >> 15);
+
+    return ticks;
+}
+
+uint8_t get_sector(uint8_t hall_a, uint8_t hall_b, uint8_t hall_c)
+{
+  uint8_t hall = hall_a * HALL_A_MASK + hall_b * HALL_B_MASK + hall_c * HALL_C_MASK;
+  return getPosition(hall);
+}
+
+void get_pwm(int dutyCycle, uint8_t sector, uint32_t *pulse_a, uint32_t *pulse_b, uint32_t *pulse_c)
+{
+    int angle = 30 + PHASE_ADVANCE_AT_MAX_PWM_DEGREES * dutyCycle / DUTY_CYCLE_100_PERCENT;
+    // This is based on Jantzen Lee's equations https://youtu.be/oHEVdXucSJs?t=510
+
+    if (dutyCycle < 0) {
+        sector = (sector + 3) % 6; // Go backwards
+    }
+    int32_t t1 = calculateT(60 - angle, ABS(dutyCycle));
+    int32_t t2 = calculateT(angle, ABS(dutyCycle));
+
+	int32_t t0 = BLDC_TIMER_PERIOD - t1 - t2;
+    if (t0 < 0) {
+        t0 = 0;
+    }
+
+    uint32_t phaseA, phaseB, phaseC;
+    svmPWM(sector, t0, t1, t2, &phaseA, &phaseB, &phaseC);
+    *pulse_a = CLAMP(phaseA, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+    *pulse_b = CLAMP(phaseB, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+    *pulse_c = CLAMP(phaseC, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+}
+
+#endif

--- a/HoverBoardGigaDevice/Tests/CMakeLists.txt
+++ b/HoverBoardGigaDevice/Tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10)
+project(commutation_tests C)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  cmocka
+  GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
+  GIT_TAG        cmocka-1.1.7
+)
+
+FetchContent_MakeAvailable(cmocka)
+
+include_directories(
+    ${cmocka_SOURCE_DIR}/include
+    ../Inc
+)
+
+add_executable(block_commutation test_block_commutation.c ../Src/blockCommutation.c)
+target_link_libraries(block_commutation cmocka)
+target_compile_definitions(block_commutation PRIVATE COMMUTATION_MODE=0)
+
+add_executable(svm_commutation test_svm_commutation.c ../Src/svmCommutation.c)
+target_link_libraries(svm_commutation cmocka)
+target_compile_definitions(svm_commutation PRIVATE COMMUTATION_MODE=1 PHASE_ADVANCE_AT_MAX_PWM_DEGREES=0)
+
+#enable_testing()
+#add_test(NAME block_commutation COMMAND block_commutation)
+#add_test(NAME svm_commutation COMMAND svm_commutation)

--- a/HoverBoardGigaDevice/Tests/test_block_commutation.c
+++ b/HoverBoardGigaDevice/Tests/test_block_commutation.c
@@ -1,0 +1,156 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include "../Inc/commutation.h"
+
+#include "test_helper.h"
+
+#define ERROR_MARGIN 1
+
+static void test_get_sector_hall_patterns(void **state)
+{
+    (void)state;
+    assert_int_equal(1, get_sector(0, 0, 1));
+    assert_int_equal(2, get_sector(1, 0, 1));
+    assert_int_equal(3, get_sector(1, 0, 0));
+    assert_int_equal(4, get_sector(1, 1, 0));
+    assert_int_equal(5, get_sector(0, 1, 0));
+    assert_int_equal(6, get_sector(0, 1, 1));
+}
+
+static void test_get_pwm_table_duty_0(void **state)
+{
+    (void)state;
+    const int duty = 0;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1125, 1125, 1125},
+        {1, 0, 1, 1125, 1125, 1125},
+        {1, 0, 0, 1125, 1125, 1125},
+        {1, 1, 0, 1125, 1125, 1125},
+        {0, 1, 0, 1125, 1125, 1125},
+        {0, 1, 1, 1125, 1125, 1125}};
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_25_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1406, 1125, 844},
+        {1, 0, 1, 1406, 844, 1125},
+        {1, 0, 0, 1125, 844, 1406},
+        {1, 1, 0, 844, 1125, 1406},
+        {0, 1, 0, 844, 1406, 1125},
+        {0, 1, 1, 1125, 1406, 844},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_25_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 844, 1125, 1406},
+        {1, 0, 1, 844, 1406, 1125},
+        {1, 0, 0, 1125, 1406, 844},
+        {1, 1, 0, 1406, 1125, 844},
+        {0, 1, 0, 1406, 844, 1125},
+        {0, 1, 1, 1125, 844, 1406},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_75_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1968, 1125, 282},
+        {1, 0, 1, 1968, 282, 1125},
+        {1, 0, 0, 1125, 282, 1968},
+        {1, 1, 0, 282, 1125, 1968},
+        {0, 1, 0, 282, 1968, 1125},
+        {0, 1, 1, 1125, 1968, 282},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_75_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 282, 1125, 1968},
+        {1, 0, 1, 282, 1968, 1125},
+        {1, 0, 0, 1125, 1968, 282},
+        {1, 1, 0, 1968, 1125, 282},
+        {0, 1, 0, 1968, 282, 1125},
+        {0, 1, 1, 1125, 282, 1968},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_100_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 2240, 1125, 10},
+        {1, 0, 1, 2240, 10, 1125},
+        {1, 0, 0, 1125, 10, 2240},
+        {1, 1, 0, 10, 1125, 2240},
+        {0, 1, 0, 10, 2240, 1125},
+        {0, 1, 1, 1125, 2240, 10},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_100_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 10, 1125, 2240},
+        {1, 0, 1, 10, 2240, 1125},
+        {1, 0, 0, 1125, 2240, 10},
+        {1, 1, 0, 2240, 1125, 10},
+        {0, 1, 0, 2240, 10, 1125},
+        {0, 1, 1, 1125, 10, 2240},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_90_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 90 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 113, 1125, 2137},
+        {1, 0, 1, 113, 2137, 1125},
+        {1, 0, 0, 1125, 2137, 113},
+        {1, 1, 0, 2137, 1125, 113},
+        {0, 1, 0, 2137, 113, 1125},
+        {0, 1, 1, 1125, 113, 2137},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_get_sector_hall_patterns),
+        cmocka_unit_test(test_get_pwm_table_duty_0),
+        cmocka_unit_test(test_get_pwm_table_duty_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_100_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_100_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_90_percent),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/HoverBoardGigaDevice/Tests/test_helper.h
+++ b/HoverBoardGigaDevice/Tests/test_helper.h
@@ -1,0 +1,44 @@
+#ifndef TEST_HELPER_H
+#define TEST_HELPER_H
+
+#include <cmocka.h>
+
+#include "mathDefines.h"
+
+typedef struct
+{
+    uint8_t hall_a;
+    uint8_t hall_b;
+    uint8_t hall_c;
+    uint32_t expected_pulse_a;
+    uint32_t expected_pulse_b;
+    uint32_t expected_pulse_c;
+} pwm_test_case_t;
+
+static void assert_int_within(int32_t expected, int32_t actual, int32_t margin) {
+    int32_t diff = ABS(expected - actual);
+    if (diff > margin) {
+        printf("Expected: %d, Actual: %d, Margin: %d (|diff|=%d)\n", expected, actual, margin, diff);
+    } 
+    assert_true(diff <= margin);
+}
+
+static void run_pwm_table_tests(int duty, const pwm_test_case_t *cases, size_t num_cases, int error_margin)
+{
+    for (size_t i = 0; i < num_cases; ++i)
+    {
+        uint8_t sector = get_sector(cases[i].hall_a, cases[i].hall_b, cases[i].hall_c);
+        uint32_t a = 0, b = 0, c = 0;
+        get_pwm(duty, sector, &a, &b, &c);
+       // printf("{ %d, %d, %d, %d, %d, %d },\n", cases[i].hall_a, cases[i].hall_b, cases[i].hall_c, a, b, c);
+       // printf("{ %d, %d, %d, %d, %d, %d },\n", cases[i].hall_a, cases[i].hall_b, cases[i].hall_c, a - cases[i].expected_pulse_a, b - cases[i].expected_pulse_b, c - cases[i].expected_pulse_c);
+     
+        fflush(stdout);
+        assert_int_within((int32_t)cases[i].expected_pulse_a, (int32_t)a, (int32_t)error_margin);
+        assert_int_within((int32_t)cases[i].expected_pulse_b, (int32_t)b, (int32_t)error_margin);
+        assert_int_within((int32_t)cases[i].expected_pulse_c, (int32_t)c, (int32_t)error_margin);
+    }
+}
+
+
+#endif

--- a/HoverBoardGigaDevice/Tests/test_svm_commutation.c
+++ b/HoverBoardGigaDevice/Tests/test_svm_commutation.c
@@ -1,0 +1,156 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include "../Inc/commutation.h"
+
+#include "test_helper.h"
+
+#define ERROR_MARGIN 200
+
+static void test_get_sector_hall_patterns(void **state)
+{
+    (void)state;
+    assert_int_equal(2, get_sector(0, 0, 1));
+    assert_int_equal(1, get_sector(1, 0, 1));
+    assert_int_equal(0, get_sector(1, 0, 0));
+    assert_int_equal(5, get_sector(1, 1, 0));
+    assert_int_equal(4, get_sector(0, 1, 0));
+    assert_int_equal(3, get_sector(0, 1, 1));
+}
+
+static void test_get_pwm_table_duty_0(void **state)
+{
+    (void)state;
+    const int duty = 0;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1125, 1125, 1125},
+        {1, 0, 1, 1125, 1125, 1125},
+        {1, 0, 0, 1125, 1125, 1125},
+        {1, 1, 0, 1125, 1125, 1125},
+        {0, 1, 0, 1125, 1125, 1125},
+        {0, 1, 1, 1125, 1125, 1125}};
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_25_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1406, 1125, 844},
+        {1, 0, 1, 1406, 844, 1125},
+        {1, 0, 0, 1125, 844, 1406},
+        {1, 1, 0, 844, 1125, 1406},
+        {0, 1, 0, 844, 1406, 1125},
+        {0, 1, 1, 1125, 1406, 844},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_25_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 844, 1125, 1406},
+        {1, 0, 1, 844, 1406, 1125},
+        {1, 0, 0, 1125, 1406, 844},
+        {1, 1, 0, 1406, 1125, 844},
+        {0, 1, 0, 1406, 844, 1125},
+        {0, 1, 1, 1125, 844, 1406},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_75_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1968, 1125, 282},
+        {1, 0, 1, 1968, 282, 1125},
+        {1, 0, 0, 1125, 282, 1968},
+        {1, 1, 0, 282, 1125, 1968},
+        {0, 1, 0, 282, 1968, 1125},
+        {0, 1, 1, 1125, 1968, 282},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_75_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 282, 1125, 1968},
+        {1, 0, 1, 282, 1968, 1125},
+        {1, 0, 0, 1125, 1968, 282},
+        {1, 1, 0, 1968, 1125, 282},
+        {0, 1, 0, 1968, 282, 1125},
+        {0, 1, 1, 1125, 282, 1968},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_100_percent(void **state)
+{
+    (void)state;
+    const int duty = DUTY_CYCLE_100_PERCENT;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 2240, 1125, 10},
+        {1, 0, 1, 2240, 10, 1125},
+        {1, 0, 0, 1125, 10, 2240},
+        {1, 1, 0, 10, 1125, 2240},
+        {0, 1, 0, 10, 2240, 1125},
+        {0, 1, 1, 1125, 2240, 10},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_100_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 10, 1125, 2240},
+        {1, 0, 1, 10, 2240, 1125},
+        {1, 0, 0, 1125, 2240, 10},
+        {1, 1, 0, 2240, 1125, 10},
+        {0, 1, 0, 2240, 10, 1125},
+        {0, 1, 1, 1125, 10, 2240},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+static void test_get_pwm_table_duty_negative_90_percent(void **state)
+{
+    (void)state;
+    const int duty = -DUTY_CYCLE_100_PERCENT * 90 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 113, 1125, 2137},
+        {1, 0, 1, 113, 2137, 1125},
+        {1, 0, 0, 1125, 2137, 113},
+        {1, 1, 0, 2137, 1125, 113},
+        {0, 1, 0, 2137, 113, 1125},
+        {0, 1, 1, 1125, 113, 2137},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]), ERROR_MARGIN);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_get_sector_hall_patterns),
+        cmocka_unit_test(test_get_pwm_table_duty_0),
+        cmocka_unit_test(test_get_pwm_table_duty_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_100_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_100_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_90_percent),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Implement field weakening to increase max RPM.

The block commutation is unchanged and now lives in `blockCommutation.c`

The space vector commutation uses Jantzen Lee sector conventions
Rename phases to A, B, C  because the green, yellow, blue colors were switched on my board which was too much for my brain.

### How to use 

To enable `#define  COMMUTATION_MODE SVM_COMMUTATION` in `config.h`
`PHASE_ADVANCE_AT_MAX_PWM_DEGREES` controls how much to advance the phase at 100% duty cycle

### Possible improvements


* Maybe the it would be possible to construct a single table that divides by `sin(60` aka (`sqrt(3) / 2`)?
* I can't work out why it spins slightly faster in one direction. Maybe there is something wrong in the math?
* Maybe there is a better way of making it spin backwards than 
```
    if (dutyCycle < 0) {
        sector = (sector + 3) % 6; // Go backwards
    }
```
* Maybe a poor mans sinusoidal commutation could be implemented by timing the hall sensors and interpolating the electrical angle of the motor. So far, results have not been promising. 

## Caveats
I'm just a hobbyist. I know that people spend their whole careers on this stuff but I think it's a good workout for the brain. I don't think this PR can do much harm because the changed behavior is disabled by default.

## SVM commutation with 8 degree angle advance at max duty

https://github.com/user-attachments/assets/f1aca336-f645-4c2f-abf6-0b5667503906

## Block commutation

https://github.com/user-attachments/assets/46149e40-04ad-4d23-84aa-26243c361a9d



