### PR TITLE
Add tests for block commutation

### DIFF
--- a/HoverBoardGigaDevice/.gitignore
+++ b/HoverBoardGigaDevice/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+Tests/build/*

--- a/HoverBoardGigaDevice/Inc/commutation.h
+++ b/HoverBoardGigaDevice/Inc/commutation.h
@@ -1,0 +1,68 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COMMUTATION_H
+#define COMMUTATION_H
+
+#include <stdint.h>
+
+/**
+ * @brief Determines the commutation sector based on Hall sensor inputs.
+ *
+ * This function interprets the states of the three Hall sensors and returns
+ * the corresponding commutation sector for BLDC motor control.
+ * Different papers and videos use different sector numbering conventions so we delegate this decision to the implementation.
+ * The convention for the sector numbering must be compatible with the get_pwm implementation.
+ * 
+ * @param hall_a State of Hall sensor A (0 or 1).
+ * @param hall_b State of Hall sensor B (0 or 1).
+ * @param hall_c State of Hall sensor C (0 or 1).
+ * @return Sector number (1-6) corresponding to the Hall sensor pattern.
+ */
+uint8_t get_sector(uint8_t hall_a, uint8_t hall_b, uint8_t hall_c);
+
+/**
+ * @brief Calculates PWM pulse values for each phase based on duty cycle and sector.
+ *
+ * This function computes the PWM pulse widths for phases A, B, and C, given the
+ * desired duty cycle and commutation sector. The results are written to the
+ * provided pointers.
+ *
+ * @param dutyCycle Desired PWM duty cycle.
+ * @param sector    Current commutation sector provided by get_sector().
+ * @param pulse_a   Pointer to store calculated PWM value for phase A.
+ * @param pulse_b   Pointer to store calculated PWM value for phase B.
+ * @param pulse_c   Pointer to store calculated PWM value for phase C.
+ */
+void get_pwm(int dutyCycle, uint8_t sector, uint32_t *pulse_a, uint32_t *pulse_b, uint32_t *pulse_c);
+
+#endif

--- a/HoverBoardGigaDevice/Inc/defines.h
+++ b/HoverBoardGigaDevice/Inc/defines.h
@@ -5,6 +5,7 @@
 #include "../Inc/setup.h"
 #include "../Inc/config.h"
 #include "../Inc/remote.h"
+#include "../Inc/mathdefines.h"
 
 
 #if defined(REMOTE_AUTODETECT)
@@ -130,15 +131,6 @@
 #ifndef ADC_BATTERY_VOLT
 	#define ADC_BATTERY_VOLT      0.024169921875  	// V_Batt to V_BattMeasure = factor 30: ( (ADC-Data/4095) *3,3V *30 )
 #endif
-
-
-// Useful math function defines
-#define ABS(a) (((a) < 0.0) ? -(a) : (a))
-#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-#ifndef MAX
-	#define MAX(x, high) (((x) > (high)) ? (high) : (x))
-#endif	
-#define MAP(x, xMin, xMax, yMin, yMax) ((x - xMin) * (yMax - yMin) / (xMax - xMin) + yMin)
 
 // ################################################################################
 

--- a/HoverBoardGigaDevice/Inc/mathDefines.h
+++ b/HoverBoardGigaDevice/Inc/mathDefines.h
@@ -1,0 +1,45 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef MATHDEFINES_H
+#define MATHDEFINES_H
+
+// Useful math function defines
+// Used from tests without including the gd headers
+
+#define ABS(a) (((a) < 0.0) ? -(a) : (a))
+#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
+#ifndef MAX
+	#define MAX(x, high) (((x) > (high)) ? (high) : (x))
+#endif	
+#define MAP(x, xMin, xMax, yMin, yMax) ((x - xMin) * (yMax - yMin) / (xMax - xMin) + yMin)
+
+#endif

--- a/HoverBoardGigaDevice/Src/bldc.c
+++ b/HoverBoardGigaDevice/Src/bldc.c
@@ -1,3 +1,36 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
 
 #include "../Inc/defines.h"
 #include <stdio.h>
@@ -55,68 +88,6 @@ int16_t up_or_down(int16_t vorher, int16_t nachher)
   return up_down[modulo(vorher-nachher, 6)];
 }
 
-// Commutation table
-const uint8_t hall_to_pos[8] =
-{
-	// annotation: for example SA=0 means hall sensor pulls SA down to Ground
-  0, // hall position [-] - No function (access from 1-6) 
-  3, // hall position [1] (SA=1, SB=0, SC=0) -> PWM-position 3
-  5, // hall position [2] (SA=0, SB=1, SC=0) -> PWM-position 5
-  4, // hall position [3] (SA=1, SB=1, SC=0) -> PWM-position 4
-  1, // hall position [4] (SA=0, SB=0, SC=1) -> PWM-position 1
-  2, // hall position [5] (SA=1, SB=0, SC=1) -> PWM-position 2
-  6, // hall position [6] (SA=0, SB=1, SC=1) -> PWM-position 6
-  0, // hall position [-] - No function (access from 1-6) 
-};
-
-//----------------------------------------------------------------------------
-// Block PWM calculation based on position
-//----------------------------------------------------------------------------
-#ifndef PLATFORMIO
-__INLINE 
-#endif
-void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)		// robo 2024/09/04: remove __INLINE for PlatformIO
-{
-  switch(pwmPos)
-	{
-    case 1:
-      *y = 0;
-      *b = pwm;
-      *g = -pwm;
-      break;
-    case 2:
-      *y = -pwm;
-      *b = pwm;
-      *g = 0;
-      break;
-    case 3:
-      *y = -pwm;
-      *b = 0;
-      *g = pwm;
-      break;
-    case 4:
-      *y = 0;
-      *b = -pwm
-		;
-      *g = pwm;
-      break;
-    case 5:
-      *y = pwm;
-      *b = -pwm;
-      *g = 0;
-      break;
-    case 6:
-      *y = pwm;
-      *b = 0;
-      *g = -pwm;
-      break;
-    default:
-      *y = 0;
-      *b = 0;
-      *g = 0;
-  }
-}
-
 //----------------------------------------------------------------------------
 // Set motor enable
 //----------------------------------------------------------------------------
@@ -129,7 +100,7 @@ void SetEnable(FlagStatus setEnable)
 // Set pwm -1000 to 1000
 //----------------------------------------------------------------------------
 void SetPWM(int16_t setPwm)
-{
+{	
 	//bldc_inputFilterPwm = CLAMP(1.125 * setPwm, -BLDC_TIMER_MID_VALUE, BLDC_TIMER_MID_VALUE); // thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
 	
 	bldc_inputFilterPwm =  BLDC_TIMER_MID_VALUE*(setPwm/1000.0);	// thanks to WizzardDr, bldc.c: pwm_res = 72000000 / 2 / PWM_FREQ; == 2250 and not 2000
@@ -142,11 +113,6 @@ extern uint32_t steerCounter;								// Steer counter for setting update rate
 // Calculation-Routine for BLDC => calculates with 16kHz
 void CalculateBLDC(void)
 {
-	int y = 0;     // yellow = phase A
-	int b = 0;     // blue   = phase B
-	int g = 0;     // green  = phase C
-
-	
 	#ifdef CURRENT_DC
 		// Calibrate ADC offsets for the first 1000 cycles
 		if (offsetcount < 1000)
@@ -205,8 +171,6 @@ void CalculateBLDC(void)
 	hall_a = digitalRead(HALL_A);
 	hall_b = digitalRead(HALL_B);
 	hall_c = digitalRead(HALL_C);
-	hall = hall_a * 1 + hall_b * 2 + hall_c * 4;
-
 
 	#ifdef TEST_HALL2LED
 		#ifdef LED_ORANGE
@@ -228,25 +192,25 @@ void CalculateBLDC(void)
 
 	// Determine current position based on hall sensors
 	#ifdef REMOTE_AUTODETECT
-		pos = AutodetectBldc(hall_to_pos[hall],buzzerTimer);
+		pos = AutodetectBldc(get_sector(hall_a, hall_b, hall_c), buzzerTimer);
 		AutodetectScan(buzzerTimer);
 	#else
-		pos = hall_to_pos[hall];
+		pos = get_sector(hall_a, hall_b, hall_c);
 	#endif
 	
-		
+
 	// Calculate low-pass filter for pwm value
 	filter_reg = filter_reg - (filter_reg >> FILTER_SHIFT) + bldc_inputFilterPwm;
 	bldc_outputFilterPwm = filter_reg >> FILTER_SHIFT;
 
+	uint32_t pulseA, pulseB, pulseC;
+	get_pwm(bldc_outputFilterPwm, pos, &pulseA, &pulseB, &pulseC);
 	// Update PWM channels based on position y(ellow), b(lue), g(reen)
-	blockPWM(bldc_outputFilterPwm, pos, &y, &b, &g);
 
 	// Set PWM output (pwm_res/2 is the mean value, setvalue has to be between 10 and pwm_res-10)
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, CLAMP(g + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, CLAMP(b + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, CLAMP(y + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE));
-
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_B, pulseA);
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_Y, pulseB);
+	timer_channel_output_pulse_value_config(TIMER_BLDC, TIMER_BLDC_CHANNEL_G, pulseC);
 	// robo23
 	iOdom = iOdom - up_or_down(lastPos, pos); // int32 will overflow at +-2.147.483.648
 	

--- a/HoverBoardGigaDevice/Src/blockCommutation.c
+++ b/HoverBoardGigaDevice/Src/blockCommutation.c
@@ -1,0 +1,122 @@
+/*
+* This file is part of the hoverboard-firmware-hack-V2 project. The 
+* firmware is used to hack the generation 2 board of the hoverboard.
+* These new hoverboards have no mainboard anymore. They consist of 
+* two Sensorboards which have their own BLDC-Bridge per Motor and an
+* ARM Cortex-M3 processor GD32F130C8.
+*
+* Copyright (C) 2018 Florian Staeblein
+* Copyright (C) 2018 Jakob Broemauer
+* Copyright (C) 2018 Kai Liebich
+* Copyright (C) 2018 Christoph Lehnert
+* Copyright (C) 2024 Robo Durden
+* Copyright (C) 2025 Hoverboard Havoc
+*
+* The program is based on the hoverboard project by Niklas Fauth. The 
+* structure was tried to be as similar as possible, so that everyone 
+* could find a better way through the code.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+
+#include "config.h"
+#include "commutation.h"
+#include "mathDefines.h"
+
+// Internal constants
+static const int16_t BLDC_TIMER_MID_VALUE = BLDC_TIMER_PERIOD / 2; // = 1125
+static const int16_t BLDC_TIMER_MIN_VALUE = 10;
+static const uint16_t BLDC_TIMER_MAX_VALUE = BLDC_TIMER_PERIOD - 10; // = 2240
+
+
+
+// Commutation table
+const uint8_t hall_to_pos[8] =
+    {
+        // annotation: for example SA=0 means hall sensor pulls SA down to Ground
+        0, // hall position [-] - No function (access from 1-6)
+        3, // hall position [1] (SA=1, SB=0, SC=0) -> PWM-position 3
+        5, // hall position [2] (SA=0, SB=1, SC=0) -> PWM-position 5
+        4, // hall position [3] (SA=1, SB=1, SC=0) -> PWM-position 4
+        1, // hall position [4] (SA=0, SB=0, SC=1) -> PWM-position 1
+        2, // hall position [5] (SA=1, SB=0, SC=1) -> PWM-position 2
+        6, // hall position [6] (SA=0, SB=1, SC=1) -> PWM-position 6
+        0, // hall position [-] - No function (access from 1-6)
+    };
+
+//----------------------------------------------------------------------------
+// Block PWM calculation based on position
+//----------------------------------------------------------------------------
+void blockPWM(int pwm, int pwmPos, int *a, int *b, int *c)		// robo 2024/09/04: remove __INLINE for PlatformIO
+{
+  switch(pwmPos)
+	{
+    case 1:
+      *b = 0;
+      *a = pwm;
+      *c = -pwm;
+      break;
+    case 2:
+      *b = -pwm;
+      *a = pwm;
+      *c = 0;
+      break;
+    case 3:
+      *b = -pwm;
+      *a = 0;
+      *c = pwm;
+      break;
+    case 4:
+      *b = 0;
+      *a = -pwm;
+      *c = pwm;
+      break;
+    case 5:
+      *b = pwm;
+      *a = -pwm;
+      *c = 0;
+      break;
+    case 6:
+      *b = pwm;
+      *a = 0;
+      *c = -pwm;
+      break;
+    default:
+      *b = 0;
+      *a = 0;
+      *c = 0;
+  }
+}
+
+uint8_t get_sector(uint8_t hall_a, uint8_t hall_b, uint8_t hall_c)
+{
+  uint8_t hall = hall_a * 1 + hall_b * 2 + hall_c * 4;
+  return hall_to_pos[hall];
+}
+
+void get_pwm(int pwm, uint8_t sector, uint32_t *pulse_a, uint32_t *pulse_b, uint32_t *pulse_c)
+{
+  int phaseA = 0; // yellow
+  int phaseB = 0; // blue
+  int phaseC = 0; // green
+
+  // Update PWM channels based on position y(ellow), b(lue), g(reen)
+  blockPWM(pwm, sector, &phaseA, &phaseB, &phaseC);
+  // Set PWM output (pwm_res/2 is the mean value, setvalue has to be between 10 and pwm_res-10)
+  *pulse_a = CLAMP(phaseA + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+  *pulse_b = CLAMP(phaseB + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+  *pulse_c = CLAMP(phaseC + BLDC_TIMER_MID_VALUE, BLDC_TIMER_MIN_VALUE, BLDC_TIMER_MAX_VALUE);
+}

--- a/HoverBoardGigaDevice/Tests/CMakeLists.txt
+++ b/HoverBoardGigaDevice/Tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.10)
+project(commutation_tests C)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  cmocka
+  GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
+  GIT_TAG        cmocka-1.1.7
+)
+
+FetchContent_MakeAvailable(cmocka)
+
+include_directories(
+    ${cmocka_SOURCE_DIR}/include
+    ../Inc
+)
+
+add_executable(test_commutation test_commutation.c ../Src/blockCommutation.c)
+target_link_libraries(test_commutation cmocka)
+
+enable_testing()
+add_test(NAME commutation_tests COMMAND test_commutation)

--- a/HoverBoardGigaDevice/Tests/test_commutation.c
+++ b/HoverBoardGigaDevice/Tests/test_commutation.c
@@ -1,0 +1,161 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include "../Inc/commutation.h"
+
+typedef struct
+{
+    uint8_t hall_a;
+    uint8_t hall_b;
+    uint8_t hall_c;
+    uint32_t expected_pulse_a;
+    uint32_t expected_pulse_b;
+    uint32_t expected_pulse_c;
+} pwm_test_case_t;
+
+static void test_get_sector_hall_patterns(void **state)
+{
+    (void)state;
+    assert_int_equal(1, get_sector(0, 0, 1));
+    assert_int_equal(2, get_sector(1, 0, 1));
+    assert_int_equal(3, get_sector(1, 0, 0));
+    assert_int_equal(4, get_sector(1, 1, 0));
+    assert_int_equal(5, get_sector(0, 1, 0));
+    assert_int_equal(6, get_sector(0, 1, 1));
+}
+
+static void run_pwm_table_tests(int duty, const pwm_test_case_t *cases, size_t num_cases)
+{
+    for (size_t i = 0; i < num_cases; ++i)
+    {
+        uint8_t sector = get_sector(cases[i].hall_a, cases[i].hall_b, cases[i].hall_c);
+        uint32_t a = 0, b = 0, c = 0;
+        get_pwm(duty, sector, &a, &b, &c);
+        //printf("{ %u, %u, %u, %u, %u, %u },\n", cases[i].hall_a, cases[i].hall_b, cases[i].hall_c, a, b, c);
+        //fflush(stdout);
+        assert_int_equal(cases[i].expected_pulse_a, a);
+        assert_int_equal(cases[i].expected_pulse_b, b);
+        assert_int_equal(cases[i].expected_pulse_c, c);
+    }
+}
+
+static void test_get_pwm_table_duty_0(void **state)
+{
+    (void)state;
+    const int duty = 0;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1125, 1125, 1125},
+        {1, 0, 1, 1125, 1125, 1125},
+        {1, 0, 0, 1125, 1125, 1125},
+        {1, 1, 0, 1125, 1125, 1125},
+        {0, 1, 0, 1125, 1125, 1125},
+        {0, 1, 1, 1125, 1125, 1125}};
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_25_percent(void **state)
+{
+    (void)state;
+    const int duty = 1125 * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1406, 1125, 844},
+        {1, 0, 1, 1406, 844, 1125},
+        {1, 0, 0, 1125, 844, 1406},
+        {1, 1, 0, 844, 1125, 1406},
+        {0, 1, 0, 844, 1406, 1125},
+        {0, 1, 1, 1125, 1406, 844},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_negative_25_percent(void **state)
+{
+    (void)state;
+    const int duty = -1125 * 25 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 844, 1125, 1406},
+        {1, 0, 1, 844, 1406, 1125},
+        {1, 0, 0, 1125, 1406, 844},
+        {1, 1, 0, 1406, 1125, 844},
+        {0, 1, 0, 1406, 844, 1125},
+        {0, 1, 1, 1125, 844, 1406},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_75_percent(void **state)
+{
+    (void)state;
+    const int duty = 1125 * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 1968, 1125, 282},
+        {1, 0, 1, 1968, 282, 1125},
+        {1, 0, 0, 1125, 282, 1968},
+        {1, 1, 0, 282, 1125, 1968},
+        {0, 1, 0, 282, 1968, 1125},
+        {0, 1, 1, 1125, 1968, 282},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_negative_75_percent(void **state)
+{
+    (void)state;
+    const int duty = -1125 * 75 / 100;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 282, 1125, 1968},
+        {1, 0, 1, 282, 1968, 1125},
+        {1, 0, 0, 1125, 1968, 282},
+        {1, 1, 0, 1968, 1125, 282},
+        {0, 1, 0, 1968, 282, 1125},
+        {0, 1, 1, 1125, 282, 1968},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_100_percent(void **state)
+{
+    (void)state;
+    const int duty = 1125;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 2240, 1125, 10},
+        {1, 0, 1, 2240, 10, 1125},
+        {1, 0, 0, 1125, 10, 2240},
+        {1, 1, 0, 10, 1125, 2240},
+        {0, 1, 0, 10, 2240, 1125},
+        {0, 1, 1, 1125, 2240, 10},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+static void test_get_pwm_table_duty_negative_100_percent(void **state)
+{
+    (void)state;
+    const int duty = -1125;
+    pwm_test_case_t cases[] = {
+        {0, 0, 1, 10, 1125, 2240},
+        {1, 0, 1, 10, 2240, 1125},
+        {1, 0, 0, 1125, 2240, 10},
+        {1, 1, 0, 2240, 1125, 10},
+        {0, 1, 0, 2240, 10, 1125},
+        {0, 1, 1, 1125, 10, 2240},
+    };
+    run_pwm_table_tests(duty, cases, sizeof(cases) / sizeof(cases[0]));
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_get_sector_hall_patterns),
+        cmocka_unit_test(test_get_pwm_table_duty_0),
+        cmocka_unit_test(test_get_pwm_table_duty_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_25_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_75_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_100_percent),
+        cmocka_unit_test(test_get_pwm_table_duty_negative_100_percent),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Before proceeding with the commutation experiments for poor man's FOC and field weakening, I wanted to add some baseline tests and an abstraction that allows the possibility for switching out the commutation with #ifdefs

Add test_commutation

To run the tests (only tested on Mac so far)

```
cd HoverBoardGigaDevice/Tests/build
cmake ..
make && ./test_commutation  
```

