### PR TITLE
Fix autodetect with PlatformIO

### DIFF
--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -15,7 +15,7 @@ build_flags =
     -D __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2=72000000UL
     -D __PIO_DONT_SET_CLOCK_SOURCE__
     -Wl,-u,_printf_float ; Enable printf float support for used in RemoteAutodetect.c
-
+board_build.ldscript = lib/spl/gd32f1x0/gd32f1x0.ld 		; 2025/06/06 robo: DeepSeek helped to fix the compilation under VisualCode+PlatformIO_plugin
 
 [env:genericGD32E230C8]
 board = genericGD32E230C8
@@ -26,3 +26,4 @@ build_flags =
     -D __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2=72000000UL
     -D __PIO_DONT_SET_CLOCK_SOURCE__
     -Wl,-u,_printf_float ; Enable printf float support for used in RemoteAutodetect.c
+board_build.ldscript = lib/spl/gd32f1x0/gd32f1x0.ld 		; 2025/06/06 robo: DeepSeek helped to fix the compilation under VisualCode+PlatformIO_plugin


### PR DESCRIPTION
Line 721 of RemoteAutoDetect.c passes floats to sprintf which does not work without the -Wl,-u,_printf_float

Remote unnecessary board_build.ldscript