### PR TITLE
Get sensor data from 6050 IMU and send to remoteUart

### DIFF
--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -27,8 +27,10 @@
 	//#define BLDC_BC			// old block commutation bldc control
 	#define BLDC_SINE			// silent sine-pwm motor control, added 2025 by Robo Durden. 
 													// not yet for target 2  = Gen2.2.x
-	
+
 #define BAT_CELLS         	10        // battery number of cells. Normal Hoverboard battery: 10s
+#define MPU_6050
+
 //#define BATTERY_LOW_SHUTOFF		// will shut off the board below BAT_LOW_DEAD = BAT_CELLS * CELL_LOW_DEAD, 
 
 	//#define MASTER		// uncomment for MASTER firmware.
@@ -38,8 +40,11 @@
 	#if defined(MASTER) || defined(SINGLE)
 		
 		// choose only one 'remote' to control the motor
-		#define REMOTE_DUMMY
-		//#define REMOTE_UART
+		#define HAS_USART1
+		#define USART1_BAUD 19200		// baudrate for remote control	
+		//#define REMOTE_DUMMY
+		#define REMOTE_UART
+
 		//#define REMOTE_UARTBUS	// ESP32 as master and multiple boards as multiple slaves ESP.tx-Hovers.rx and ESP.rx-Hovers.tx
 		//#define REMOTE_CRSF		// https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/26
 		//#define REMOTE_ADC	// speed is PA2=TX and steer is PA3=RX of the masterslave header. Get 3.3V from the flash header
@@ -50,7 +55,14 @@
 												// When the melody returns for 2 seconds, push speed to max.
 												// After another 5 seconds + 2 seconds melody: push speed to min. Then steer to max. Finally steer to min
 		
-		
+		#ifdef REMOTE_UART
+			#define SEND_IMU_DATA // send the IMU data to the remote control
+			#ifdef SEND_IMU_DATA
+				#ifndef MPU_6050
+					#error "You have to define MPU_6050 to use SEND_IMU_DATA"
+				#endif 
+			#endif
+		#endif
 		#ifdef REMOTE_UARTBUS
 			#define SLAVE_ID	0		// must be unique for all hoverboards connected to the bus
 		#endif
@@ -109,5 +121,14 @@
 #define DELAY_IN_MAIN_LOOP 	5         // Delay in ms
 
 #define TIMEOUT_MS          2000      // Time in milliseconds without steering commands before pwm emergency off
+
+#ifdef MPU_6050
+#define I2C_ENABLE
+#endif 
+
+#ifdef I2C_ENABLE
+	#define I2C_SPEED             400000      // [bit/s] Define I2C speed for communicating with the MPU6050
+	#define I2C_PERIPH I2C0
+#endif
 
 #endif		// CONFIG_H

--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -29,7 +29,6 @@
 													// not yet for target 2  = Gen2.2.x
 
 #define BAT_CELLS         	10        // battery number of cells. Normal Hoverboard battery: 10s
-#define MPU_6050
 
 //#define BATTERY_LOW_SHUTOFF		// will shut off the board below BAT_LOW_DEAD = BAT_CELLS * CELL_LOW_DEAD, 
 
@@ -58,9 +57,7 @@
 		#ifdef REMOTE_UART
 			#define SEND_IMU_DATA // send the IMU data to the remote control
 			#ifdef SEND_IMU_DATA
-				#ifndef MPU_6050
-					#error "You have to define MPU_6050 to use SEND_IMU_DATA"
-				#endif 
+				#define MPU_6050
 			#endif
 		#endif
 		#ifdef REMOTE_UARTBUS

--- a/HoverBoardGigaDevice/Inc/defines.h
+++ b/HoverBoardGigaDevice/Inc/defines.h
@@ -195,6 +195,51 @@
 #endif
 
 
+
+#ifdef MPU_6050
+    #define I2C_ENABLE
+
+	#define MPU_I2C                     I2C_PERIPH
+
+	typedef struct{
+		int16_t     x;
+		int16_t     y;
+		int16_t     z; 
+	} Gyro;
+
+	typedef struct{
+		int16_t     x;
+		int16_t     y;
+		int16_t     z; 
+	} Accel;
+
+	typedef struct {
+		Gyro        gyro;
+		Accel       accel;
+		int16_t     temperature;
+	} MPU_Data;
+
+#endif
+
+#ifdef I2C_ENABLE
+	#define I2C_OWN_ADDRESS7            0x24
+
+	#define I2C_TIMEOUT  10000
+	#define I2C_ACK_ENABLE  1
+	#define I2C_ACK_DISABLE 0
+
+	#define MPU_RCU_I2C                 RCU_I2C0
+	#define MPU_SCL_GPIO_Port           GPIOB
+	#define MPU_SCL_PIN                 GPIO_PIN_6
+	#define MPU_SDA_GPIO_Port           GPIOB
+	#define MPU_SDA_PIN                 GPIO_PIN_7
+
+	// return values
+	#define I2C_OK    0
+	#define I2C_ERR  -1
+#endif
+
+
 // Useful math function defines
 #define ABS(a) (((a) < 0.0) ? -(a) : (a))
 #define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/HoverBoardGigaDevice/Inc/defines/defines_2-1-20.h
+++ b/HoverBoardGigaDevice/Inc/defines/defines_2-1-20.h
@@ -29,8 +29,8 @@
 #define TIMER_BLDC_PULLUP	GPIO_PUPD_NONE	// robo: not sure if some boards indeed nned GPIO_PUPD_PULLUP like 2.2 or 2.3
 
 // GD32F130 USART0 TX/RX:	(PA9/PA10)AF1	, (PB6/PB7)AF0 , 	(PA2/PA3)AF1 , (PA14/PA15)AF1 GD32F130x4 only!
-#define USART0_TX	PB6	// you have to solder to the tiny IMU: https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/90#issuecomment-2949589576
-#define USART0_RX	PB7	// you have to solder to the tiny IMU: https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/90#issuecomment-2949589576
+//#define USART0_TX	PB6	// you have to solder to the tiny IMU: https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/90#issuecomment-2949589576
+//#define USART0_RX	PB7	// you have to solder to the tiny IMU: https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/90#issuecomment-2949589576
 
 // GD32F130 USART1 GD32F130 TX/RX: (PA14/PA15)AF1 , (PA2,PA3)AF1	, (PA8/PB0)AlternateFunction4
 #define USART1_TX		PA2

--- a/HoverBoardGigaDevice/Inc/i2c.h
+++ b/HoverBoardGigaDevice/Inc/i2c.h
@@ -1,0 +1,39 @@
+/**
+  * This file was part of the hoverboard-sideboard-hack project but got re-written
+  * to remove the interrupts and use a blocking I2C implementation.
+  *
+  * Copyright (C) 2020-2021 Emanuel FERU <aerdronix@gmail.com>
+  * Copyright (C) 2025 Hoverboard Havoc
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Define to prevent recursive inclusion
+#ifndef I2C_H
+#define I2C_H
+
+#include <stdint.h>
+
+#ifdef I2C_ENABLE
+/* i2c write/read functions */
+int8_t i2c_writeBytes(uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
+int8_t i2c_writeByte (uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t data);
+int8_t i2c_writeBit  (uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t bitNum, uint8_t  data);
+int8_t i2c_readBytes (uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
+int8_t i2c_readByte  (uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t *data);
+int8_t i2c_readBit   (uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data);
+
+#endif // I2C_ENABLE
+#endif // I2C_H
+

--- a/HoverBoardGigaDevice/Inc/mpu6050.h
+++ b/HoverBoardGigaDevice/Inc/mpu6050.h
@@ -1,0 +1,37 @@
+/**
+  * Copyright (C) 2011-2012 InvenSense Corporation, All Rights Reserved.
+  * Copyright (C) 2020-2021 Emanuel FERU <aerdronix@gmail.com>
+  * Copyright (C) 2025 Hoverboard Havoc
+  *
+  * Copyright (C) 2020-2021 Emanuel FERU <aerdronix@gmail.com>
+  * Copyright (C) 2011-2012 InvenSense Corporation, All Rights Reserved.
+  * Copyright (C) 2025 Hoverboard Havoc
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Define to prevent recursive inclusion
+#ifndef MPU6050_H
+#define MPU6050_H
+#ifdef  MPU_6050
+
+#include <stdint.h>
+#include "defines.h"
+
+int mpu_init();
+int mpu_read_all();
+
+#endif // MPU_6050
+#endif // MPU6050_H
+

--- a/HoverBoardGigaDevice/Inc/remote.h
+++ b/HoverBoardGigaDevice/Inc/remote.h
@@ -6,6 +6,9 @@
 	void RemoteCallback(void);		// must be implemented by all remotes
 	void RemoteUpdate(void);			// must be implemented by all remotes
 
+	#ifdef SEND_IMU_DATA
+		void RemoteUpdateIMU();	// Send IMU data
+	#endif
 
 	#if defined(REMOTE_UART)
 		#include "../Inc/remoteUart.h"

--- a/HoverBoardGigaDevice/Inc/setup.h
+++ b/HoverBoardGigaDevice/Inc/setup.h
@@ -98,6 +98,13 @@ void USART_MasterSlave_init(void);
 //----------------------------------------------------------------------------
 void USART_Steer_COM_init(void);
 
+//----------------------------------------------------------------------------
+// Initializes the I2C
+//----------------------------------------------------------------------------
+#ifdef I2C_ENABLE
+void i2c_config(void);
+#endif
+
 
 void ConfigReset(void);
 void ConfigWrite(void);

--- a/HoverBoardGigaDevice/Src/i2c.c
+++ b/HoverBoardGigaDevice/Src/i2c.c
@@ -1,0 +1,230 @@
+/**
+  * This file was part of the hoverboard-sideboard-hack project but got re-written
+  * to remove the interrupts and use a blocking I2C implementation.
+  *
+  * Copyright (C) 2020-2021 Emanuel FERU <aerdronix@gmail.com>
+  * Copyright (C) 2025 Hoverboard Havoc
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Includes
+#include <stdio.h>
+#include <string.h>
+#include "gd32f1x0.h"
+#include "defines.h"
+#include "config.h"
+#include "setup.h"
+#include "i2c.h"
+#include "target.h"
+
+#ifdef I2C_ENABLE
+
+//------------------------------------------------------------------------------
+// Blocking write of N bytes to device @devAddr, register @regAddr.
+//------------------------------------------------------------------------------
+int8_t i2c_writeBytes(
+                      uint32_t i2c_periph,
+                      uint8_t devAddr,
+                      uint8_t regAddr,
+                      uint8_t length,
+                      uint8_t *data)
+{
+    uint32_t tmo = 0;
+
+    // 1) wait for bus idle
+    while (i2c_flag_get(i2c_periph, I2C_FLAG_I2CBSY)) {
+        if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+    }
+
+    // 2) send START
+    i2c_start_on_bus(i2c_periph);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_SBSEND)) {
+        if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+    }
+
+    // 3) send slave address + write bit
+    //     — GD32 uses I2C_TRANSMITTER / I2C_RECEIVER
+    i2c_master_addressing(i2c_periph, devAddr << 1, I2C_TRANSMITTER);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_ADDSEND)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+    // clear the address‐sent flag
+    i2c_flag_clear(i2c_periph, I2C_FLAG_ADDSEND);
+
+    // 4) send register address
+    i2c_data_transmit(i2c_periph, regAddr);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_TBE)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+
+    // 5) send payload bytes
+    for (uint8_t i = 0; i < length; i++) {
+        i2c_data_transmit(i2c_periph, data[i]);
+        tmo = 0;
+        while (!i2c_flag_get(i2c_periph, I2C_FLAG_TBE)) {
+            if (++tmo > I2C_TIMEOUT) {
+                i2c_stop_on_bus(i2c_periph);
+                return I2C_ERR;
+            }
+        }
+    }
+
+    // 6) wait for transfer complete, then STOP
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_BTC)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+    i2c_stop_on_bus(i2c_periph);
+
+    return I2C_OK;
+}
+
+
+/*
+ * write 1 byte to chip register
+ */
+int8_t i2c_writeByte(uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t data)
+{
+    return i2c_writeBytes(i2c_periph, slaveAddr, regAddr, 1, &data);
+}
+
+
+/*
+ * write one bit to chip register
+ */
+int8_t i2c_writeBit(uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data) {
+    uint8_t b;
+    i2c_readByte(i2c_periph, slaveAddr, regAddr, &b);
+    b = (data != 0) ? (b | (1 << bitNum)) : (b & ~(1 << bitNum));
+    return i2c_writeByte(i2c_periph, slaveAddr, regAddr, b);
+}
+
+
+
+/* =========================== I2C READ Functions =========================== */
+
+//------------------------------------------------------------------------------
+// Blocking read of N bytes into data[] from device @devAddr, register @regAddr.
+//------------------------------------------------------------------------------
+int8_t i2c_readBytes(uint32_t i2c_periph,
+                     uint8_t devAddr,
+                     uint8_t regAddr,
+                     uint8_t length,
+                     uint8_t *data)
+{
+    uint32_t tmo = 0;
+
+    // 1) wait for bus idle
+    while (i2c_flag_get(i2c_periph, I2C_FLAG_I2CBSY)) {
+        if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+    }
+
+    // 2) send START + slave addr (write) + regAddr
+    i2c_start_on_bus(i2c_periph);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_SBSEND)) {
+        if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+    }
+
+    i2c_master_addressing(i2c_periph, devAddr << 1, I2C_TRANSMITTER);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_ADDSEND)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+    i2c_flag_clear(i2c_periph, I2C_FLAG_ADDSEND);
+
+    i2c_data_transmit(i2c_periph, regAddr);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_TBE)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+
+    // 3) repeated-start for read
+    i2c_start_on_bus(i2c_periph);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_SBSEND)) {
+        if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+    }
+
+    i2c_master_addressing(i2c_periph, devAddr << 1, I2C_RECEIVER);
+    tmo = 0;
+    while (!i2c_flag_get(i2c_periph, I2C_FLAG_ADDSEND)) {
+        if (++tmo > I2C_TIMEOUT) {
+            i2c_stop_on_bus(i2c_periph);
+            return I2C_ERR;
+        }
+    }
+    i2c_flag_clear(i2c_periph, I2C_FLAG_ADDSEND);
+
+    // 4) read each byte
+    for (uint8_t i = 0; i < length; i++) {
+        // on last byte, disable ACK and send STOP
+        if (i == length - 1) {
+            i2c_ack_config(i2c_periph, I2C_ACK_DISABLE);
+            i2c_stop_on_bus(i2c_periph);
+        }
+        tmo = 0;
+        while (!i2c_flag_get(i2c_periph, I2C_FLAG_RBNE)) {
+            if (++tmo > I2C_TIMEOUT) return I2C_ERR;
+        }
+        data[i] = i2c_data_receive(i2c_periph);
+    }
+
+    // re-enable ACK for next time
+    i2c_ack_config(i2c_periph, I2C_ACK_ENABLE);
+
+    return I2C_OK;
+}
+
+
+/*
+ * read 1 byte from chip register
+ */
+int8_t i2c_readByte(uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t *data)
+{
+    return i2c_readBytes(i2c_periph, slaveAddr, regAddr, 1, data);
+}
+
+
+/*
+ * read 1 bit from chip register
+ */
+int8_t i2c_readBit(uint32_t i2c_periph, uint8_t slaveAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data)
+{
+    uint8_t b;
+    int8_t status = i2c_readByte(i2c_periph, slaveAddr, regAddr, &b);
+    *data = b & (1 << bitNum);
+    return status;
+}
+
+#endif // I2C_ENABLE

--- a/HoverBoardGigaDevice/Src/main.c
+++ b/HoverBoardGigaDevice/Src/main.c
@@ -6,7 +6,8 @@
 #include "../Inc/it.h"
 #include "../Inc/bldc.h"
 #include "../Inc/commsMasterSlave.h"
-
+#include "../Inc/i2c.h"
+#include "../Inc/mpu6050.h"
 //#include "../Inc/commsSteering.h"
 
 #include "../Inc/commsBluetooth.h"
@@ -83,6 +84,8 @@ void ShowBatteryState(int8_t iLevel);
 	
 
 uint32_t iTimeNextLoop = 0;
+
+
 //----------------------------------------------------------------------------
 // MAIN function
 //----------------------------------------------------------------------------
@@ -144,6 +147,12 @@ iBug = 6;
 			USART2_Init(USART2_BAUD);
 	#endif
 	
+#ifdef I2C_ENABLE
+	i2c_config();
+#endif 
+#ifdef MPU_6050
+	mpu_init();
+#endif
 	// Init ADC
 	ADC_init();
 iBug = 7;	
@@ -218,12 +227,19 @@ iBug = 9;
 
 	while(1)
 	{
+
+
+
 		if (millis() < iTimeNextLoop)	
 			continue;
 		iTimeNextLoop = millis() + DELAY_IN_MAIN_LOOP;
 		steerCounter++;		// something like DELAY_IN_MAIN_LOOP = 5 ms
 		DEBUG_LedSet(	(steerCounter%20) < 10	,0)
 		
+		#ifdef MPU_6050
+			mpu_read_all();
+		#endif
+
 		
 		#ifdef MOSFET_OUT
 			digitalWrite(MOSFET_OUT,	(steerCounter%200) < 100	);	// onboard led blinking :-)

--- a/HoverBoardGigaDevice/Src/main.c
+++ b/HoverBoardGigaDevice/Src/main.c
@@ -227,9 +227,6 @@ iBug = 9;
 
 	while(1)
 	{
-
-
-
 		if (millis() < iTimeNextLoop)	
 			continue;
 		iTimeNextLoop = millis() + DELAY_IN_MAIN_LOOP;
@@ -237,7 +234,11 @@ iBug = 9;
 		DEBUG_LedSet(	(steerCounter%20) < 10	,0)
 		
 		#ifdef MPU_6050
-			mpu_read_all();
+			if (mpu_read_all() == SUCCESS) {
+				#ifdef SEND_IMU_DATA
+					RemoteUpdateIMU();		// Send IMU data to remote
+				#endif
+			}
 		#endif
 
 		

--- a/HoverBoardGigaDevice/Src/mpu6050.c
+++ b/HoverBoardGigaDevice/Src/mpu6050.c
@@ -1,0 +1,335 @@
+/**
+  * Copyright (C) 2020-2021 Emanuel FERU <aerdronix@gmail.com>
+  * Copyright (C) 2011-2012 InvenSense Corporation, All Rights Reserved.
+  * Copyright (C) 2025 Hoverboard Havoc
+  * 
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Includes
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "../Inc/it.h" // for Delay 🤷
+#include "../Inc/defines.h"
+#include "../Inc/config.h"
+#include "../Inc/i2c.h"
+#include "../Inc/mpu6050.h"
+
+#ifdef MPU_6050
+
+MPU_Data mpuData;                                       // holds the MPU-6050 data
+static ErrStatus    mpuStatus;                  // holds the MPU-6050 status: SUCCESS or ERROR
+
+int mpu_config(void);
+
+int mpu_init() {
+       int result = mpu_config();
+       if(result) {                              // IMU MPU-6050 config
+            mpuStatus = ERROR;
+            digitalWrite(LED_RED,SET);
+            digitalWrite(LED_GREEN,RESET);
+        }
+        else {
+            mpuStatus = SUCCESS;
+            digitalWrite(LED_RED, RESET);
+            digitalWrite(LED_GREEN,SET);
+        }
+        return result;
+}
+
+/* Hardware registers needed by driver. */
+struct gyro_reg_s {
+    unsigned char who_am_i;
+    unsigned char rate_div;
+    unsigned char lpf;
+    unsigned char prod_id;
+    unsigned char user_ctrl;
+    unsigned char fifo_en;
+    unsigned char gyro_cfg;
+    unsigned char accel_cfg;
+    unsigned char accel_cfg2;
+    unsigned char lp_accel_odr;
+    unsigned char motion_thr;
+    unsigned char motion_dur;
+    unsigned char fifo_count_h;
+    unsigned char fifo_r_w;
+    unsigned char raw_gyro;
+    unsigned char raw_accel;
+    unsigned char temp;
+    unsigned char int_enable;
+    unsigned char dmp_int_status;
+    unsigned char int_status;
+    unsigned char accel_intel;
+    unsigned char pwr_mgmt_1;
+    unsigned char pwr_mgmt_2;
+    unsigned char int_pin_cfg;
+    unsigned char mem_r_w;
+    unsigned char accel_offs;
+    unsigned char i2c_mst;
+    unsigned char bank_sel;
+    unsigned char mem_start_addr;
+    unsigned char prgm_start_h;
+};
+
+/* Information specific to a particular device. */
+struct hw_s {
+    unsigned char addr;
+    unsigned short max_fifo;
+    unsigned char num_reg;
+    unsigned short temp_sens;
+    short temp_offset;
+    unsigned short bank_size;
+};
+
+/* Gyro driver state variables. */
+struct gyro_state_s {
+    const struct gyro_reg_s *reg;
+    const struct hw_s *hw;
+};
+
+/* Filter configurations. */
+enum lpf_e {
+    INV_FILTER_256HZ_NOLPF2 = 0,
+    INV_FILTER_188HZ,
+    INV_FILTER_98HZ,
+    INV_FILTER_42HZ,
+    INV_FILTER_20HZ,
+    INV_FILTER_10HZ,
+    INV_FILTER_5HZ,
+    INV_FILTER_2100HZ_NOLPF,
+    NUM_FILTER
+};
+
+/* Full scale ranges. */
+enum gyro_fsr_e {
+    INV_FSR_250DPS = 0,
+    INV_FSR_500DPS,
+    INV_FSR_1000DPS,
+    INV_FSR_2000DPS,
+    NUM_GYRO_FSR
+};
+
+/* Full scale ranges. */
+enum accel_fsr_e {
+    INV_FSR_2G = 0,
+    INV_FSR_4G,
+    INV_FSR_8G,
+    INV_FSR_16G,
+    NUM_ACCEL_FSR
+};
+
+/* Clock sources. */
+enum clock_sel_e {
+    INV_CLK_INTERNAL = 0,
+    INV_CLK_PLL,
+    NUM_CLK
+};
+
+#define BIT_I2C_MST_VDDIO   (0x80)
+#define BIT_FIFO_EN         (0x40)
+#define BIT_DMP_EN          (0x80)
+#define BIT_FIFO_RST        (0x04)
+#define BIT_DMP_RST         (0x08)
+#define BIT_FIFO_OVERFLOW   (0x10)
+#define BIT_DATA_RDY_EN     (0x01)
+#define BIT_DMP_INT_EN      (0x02)
+#define BIT_MOT_INT_EN      (0x40)
+#define BITS_FSR            (0x18)
+#define BITS_LPF            (0x07)
+#define BITS_HPF            (0x07)
+#define BITS_CLK            (0x07)
+#define BIT_FIFO_SIZE_1024  (0x40)
+#define BIT_FIFO_SIZE_2048  (0x80)
+#define BIT_FIFO_SIZE_4096  (0xC0)
+#define BIT_RESET           (0x80)
+#define BIT_SLEEP           (0x40)
+#define BIT_S0_DELAY_EN     (0x01)
+#define BIT_S2_DELAY_EN     (0x04)
+#define BITS_SLAVE_LENGTH   (0x0F)
+#define BIT_SLAVE_BYTE_SW   (0x40)
+#define BIT_SLAVE_GROUP     (0x10)
+#define BIT_SLAVE_EN        (0x80)
+#define BIT_I2C_READ        (0x80)
+#define BITS_I2C_MASTER_DLY (0x1F)
+#define BIT_AUX_IF_EN       (0x20)
+#define BIT_ACTL            (0x80)
+#define BIT_LATCH_EN        (0x20)
+#define BIT_ANY_RD_CLR      (0x10)
+#define BIT_BYPASS_EN       (0x02)
+#define BITS_WOM_EN         (0xC0)
+#define BIT_LPA_CYCLE       (0x20)
+#define BIT_STBY_XA         (0x20)
+#define BIT_STBY_YA         (0x10)
+#define BIT_STBY_ZA         (0x08)
+#define BIT_STBY_XG         (0x04)
+#define BIT_STBY_YG         (0x02)
+#define BIT_STBY_ZG         (0x01)
+#define BIT_STBY_XYZA       (BIT_STBY_XA | BIT_STBY_YA | BIT_STBY_ZA)
+#define BIT_STBY_XYZG       (BIT_STBY_XG | BIT_STBY_YG | BIT_STBY_ZG)
+
+
+const struct gyro_reg_s reg = {
+    .who_am_i       = 0x75,
+    .rate_div       = 0x19,
+    .lpf            = 0x1A, // Set to 0x03
+    .prod_id        = 0x0C,
+    .user_ctrl      = 0x6A,
+    .fifo_en        = 0x23,
+    .gyro_cfg       = 0x1B, // Set to 0x00  GYRO_CONFIG: FS_SEL = 0 → ±250 °/s
+    .accel_cfg      = 0x1C, // // ACCEL_CONFIG: AFS_SEL = 0 → ±2 g
+    .motion_thr     = 0x1F,
+    .motion_dur     = 0x20,
+    .fifo_count_h   = 0x72,
+    .fifo_r_w       = 0x74,
+    .raw_gyro       = 0x43,
+    .raw_accel      = 0x3B,
+    .temp           = 0x41,
+    .int_enable     = 0x38,
+    .dmp_int_status = 0x39,
+    .int_status     = 0x3A,
+    .pwr_mgmt_1     = 0x6B, // PWR_MGMT_1: clear sleep bit
+    .pwr_mgmt_2     = 0x6C,
+    .int_pin_cfg    = 0x37,
+    .mem_r_w        = 0x6F,
+    .accel_offs     = 0x06,
+    .i2c_mst        = 0x24,
+    .bank_sel       = 0x6D,
+    .mem_start_addr = 0x6E,
+    .prgm_start_h   = 0x70
+};
+const struct hw_s hw = {
+    .addr           = 0x68,
+    .max_fifo       = 1024,
+    .num_reg        = 118,
+    .temp_sens      = 340,
+    .temp_offset    = -521,
+    .bank_size      = 256
+};
+
+static struct gyro_state_s st = {
+    .reg = &reg,
+    .hw = &hw
+};
+
+
+int mpu_config(void)
+{
+    // This is mine
+    int8_t rc;
+
+    // 1) Wake up & switch clock to PLL on X-gyro
+    //    INV_CLK_PLL == 1 → CLKSEL = 1
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.pwr_mgmt_1,
+                       INV_CLK_PLL   /* bits[2:0] = 001 */ 
+                       /* sleep bit (6) is 0 by default */ );
+    if (rc) return rc;
+
+    // small delay for the oscillator to stabilize
+    Delay(10);
+
+    // 2) Disable DMP & FIFO
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.user_ctrl,
+                       0 /* BIT_DMP_EN=0, BIT_FIFO_EN=0 */);
+    if (rc) return rc;
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.fifo_en,
+                       0 /* no gyro/accel to FIFO */);
+    if (rc) return rc;
+
+    // 3) Sample rate divider: 1 kHz/(1 + DIV) → here DIV = 4 → 200 Hz
+    //    Use the raw value; there’s no enum for SMPLRT_DIV
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.rate_div,
+                       4);
+    if (rc) return rc;
+
+    // 4) Configure DLPF_CFG to 42 Hz
+    //    INV_FILTER_42HZ == 3 → bits[2:0] = 011
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.lpf,
+                       INV_FILTER_42HZ /* 3 */);
+    if (rc) return rc;
+
+    // 5) Full-scale ranges
+    //    Gyro FS_SEL bits[4:3] ← INV_FSR_250DPS << 3
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.gyro_cfg,
+                       (INV_FSR_250DPS << 3));  // 0 << 3 = 0
+    if (rc) return rc;
+    //    Accel AFS_SEL bits[4:3] ← INV_FSR_2G << 3
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.accel_cfg,
+                       (INV_FSR_2G << 3));      // 0 << 3 = 0
+    if (rc) return rc;
+
+    // 6) INT pin: active-high, push-pull, latch until cleared
+    //    BIT_ACTL=0, BIT_LATCH_EN=1<<5, BIT_ANY_RD_CLR=1<<4
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.int_pin_cfg,
+                       BIT_LATCH_EN | BIT_ANY_RD_CLR);
+    if (rc) return rc;
+
+    // 7) Enable only the Data Ready interrupt
+    //    BIT_DATA_RDY_EN = 1<<0
+    rc = i2c_writeByte(MPU_I2C,
+                       hw.addr,
+                       reg.int_enable,
+                       BIT_DATA_RDY_EN);
+    if (rc) return rc;
+
+    return 0;
+}
+
+int mpu_read_all()
+{
+    if (SUCCESS == mpuStatus) {
+        uint8_t buf[14];
+
+            // burst‐read accel(6) + temp(2) + gyro(6)
+            // auto‐increment register address in MPU-6050
+            
+            if (i2c_readBytes(MPU_I2C, st.hw->addr, st.reg->raw_accel, 14, buf) != I2C_OK) {
+                // handle I2C error here if you need to
+                return ERROR;
+            }
+
+            // unpack accel
+            mpuData.accel.x = (int16_t)((buf[0] << 8) | buf[1]);
+            mpuData.accel.y = (int16_t)((buf[2] << 8) | buf[3]);
+            mpuData.accel.z = (int16_t)((buf[4] << 8) | buf[5]);
+
+            // unpack temp
+            mpuData.temperature    = (int16_t)((buf[6] << 8) | buf[7]);
+
+            // unpack gyro
+            mpuData.gyro.x  = (int16_t)((buf[8]  << 8) | buf[9]);
+            mpuData.gyro.y  = (int16_t)((buf[10] << 8) | buf[11]);
+            mpuData.gyro.z  = (int16_t)((buf[12] << 8) | buf[13]);
+    } 
+    return mpuStatus;
+}
+
+#endif // MPU_6050

--- a/HoverBoardGigaDevice/Src/remoteUart.c
+++ b/HoverBoardGigaDevice/Src/remoteUart.c
@@ -34,7 +34,11 @@ extern DataSlave oDataSlave;
 extern uint8_t  wStateSlave;
 extern uint8_t  wState;
 
-typedef struct {			// ´#pragma pack(1)´ needed to get correct sizeof()
+#ifdef SEND_IMU_DATA
+extern MPU_Data mpuData;	
+#endif
+
+typedef struct {			// ï¿½#pragma pack(1)ï¿½ needed to get correct sizeof()
    uint8_t cStart;		//  = '/';
    //uint16_t cStart;		//  = #define START_FRAME         0xABCD
    int16_t  iSpeed;
@@ -47,15 +51,24 @@ typedef struct {			// ´#pragma pack(1)´ needed to get correct sizeof()
 static uint8_t aReceiveBuffer[sizeof(SerialServer2Hover)];
 
 #define START_FRAME         0xABCD       // [-] Start frme definition for reliable serial communication
-typedef struct{				// ´#pragma pack(1)´ needed to get correct sizeof()
+typedef struct{				// ï¿½#pragma pack(1)ï¿½ needed to get correct sizeof()
    uint16_t cStart;
    int16_t iSpeedL;		// 100* km/h
    int16_t iSpeedR;		// 100* km/h
    uint16_t iVolt;		// 100* V
-   int16_t iAmpL;			// 100* A
-   int16_t iAmpR;			// 100* A
+   int16_t iAmpL;		// 100* A
+   int16_t iAmpR;		// 100* A
    int32_t iOdomL;		// hall steps
    int32_t iOdomR;		// hall steps
+#ifdef SEND_IMU_DATA
+	int16_t     iGyroX;
+	int16_t     iGyroY;
+	int16_t     iGyroZ; 
+	int16_t     iAccelX;
+	int16_t     iAccelY;
+	int16_t     iAccelZ;
+	int16_t     iTemperature;
+#endif
    uint16_t checksum;
 } SerialHover2Server;
 
@@ -99,6 +112,17 @@ void RemoteUpdate(void)
 		oData.iSpeedR = 0;
 		oData.iOdomR = 0;
 	#endif
+
+	#ifdef SEND_IMU_DATA
+		oData.iGyroX = mpuData.gyro.x;
+		oData.iGyroY = mpuData.gyro.y;
+		oData.iGyroZ = mpuData.gyro.z;
+		oData.iAccelX = mpuData.accel.x;
+		oData.iAccelY = mpuData.accel.y;
+		oData.iAccelZ = mpuData.accel.z;
+		oData.iTemperature = mpuData.temperature;
+	#endif
+	
 /*	
 	oData.iVolt = aDebug[0];
 	oData.iAmpL = aDebug[1];

--- a/HoverBoardGigaDevice/Src/setup.c
+++ b/HoverBoardGigaDevice/Src/setup.c
@@ -150,6 +150,21 @@ void GPIO_init(void)
 	rcu_periph_clock_enable(RCU_GPIOB);
 	rcu_periph_clock_enable(RCU_GPIOC);
 	rcu_periph_clock_enable(RCU_GPIOF);
+
+	#ifdef I2C_ENABLE
+		// TODO use pinModeAF 
+		rcu_periph_clock_enable(MPU_RCU_I2C);
+
+		 /* connect PB6 to I2C_SCL and PB7 to I2C_SDA */
+		gpio_af_set(MPU_SCL_GPIO_Port, GPIO_AF_1, MPU_SCL_PIN);
+		gpio_af_set(MPU_SDA_GPIO_Port, GPIO_AF_1, MPU_SDA_PIN);
+
+		/* configure GPIO port */
+		gpio_mode_set(MPU_SCL_GPIO_Port, GPIO_MODE_AF, GPIO_PUPD_PULLUP, MPU_SCL_PIN);
+		gpio_output_options_set(MPU_SCL_GPIO_Port, GPIO_OTYPE_OD, GPIO_OSPEED_50MHZ, MPU_SCL_PIN);	
+		gpio_mode_set(MPU_SDA_GPIO_Port, GPIO_MODE_AF, GPIO_PUPD_PULLUP, MPU_SDA_PIN);
+		gpio_output_options_set(MPU_SDA_GPIO_Port, GPIO_OTYPE_OD, GPIO_OSPEED_50MHZ, MPU_SDA_PIN);
+	#endif 
 	
 	#ifdef TIMER_BLDC_EMERGENCY_SHUTDOWN
 		// Init emergency shutdown pin
@@ -894,8 +909,18 @@ void USART2_Init(uint32_t iBaud)	// only for target==2 = gd32f103
 #endif
 }
 
-
-
+#ifdef I2C_ENABLE
+void i2c_config(void) {
+    /* I2C clock configure */
+     i2c_clock_config(I2C_PERIPH, I2C_SPEED, I2C_DTCY_16_9);            // I2C duty cycle in fast mode plus
+    /* I2C address configure */
+    i2c_mode_addr_config(I2C_PERIPH, I2C_I2CMODE_ENABLE, I2C_ADDFORMAT_7BITS, I2C_OWN_ADDRESS7);
+    /* enable I2C */
+    i2c_enable(I2C_PERIPH);
+    /* enable acknowledge */
+    i2c_ack_config(I2C_PERIPH, I2C_ACK_ENABLE);
+}
+#endif
 
 # define TRUE												0x01
 # define FALSE												0x00


### PR DESCRIPTION
Get sensor data from 6050 IMU and send to remoteUart

`#define SEND_IMU_DATA` turns on sending IMU data for `remoteUart`. ~This is a breaking protocol change.~ This is now backwards compatible with the old protocol.

`#define MPU_6050` turns on the IMU 6050 code (and the supporting i2c code (I2C_ENABLE)

# TODO 

* Define i2c pins in defines file
* use `pinModeAF` to setup i2c GPIO