### PR TITLE
Update flash code

### DIFF
--- a/HoverBoardGigaDevice/Inc/defines.h
+++ b/HoverBoardGigaDevice/Inc/defines.h
@@ -228,7 +228,6 @@ typedef struct
 
 
 
-	
 #ifdef REMOTE_AUTODETECT
 	#define PINS_DETECT 18
 		
@@ -239,22 +238,23 @@ typedef struct
 		uint32_t iVersion;
 		uint16_t wState;
 		int8_t aiPinScan[PINS_DETECT];		// lists NOT the uint32_t PA7 but the index of PA7 in PinAD aoPin[COUNT_PinDigital]
+		uint8_t padding[1];  // Pad to x*4 bytes for word alignment.
 	} ConfigData;
 	#pragma pack(pop)
 #else	
-	#define EEPROM_VERSION 1
+	#define EEPROM_VERSION 2
 
 	#pragma pack(push, 1)
-	typedef struct
-	{
-		uint32_t iVersion;
-		uint16_t wState;
-		uint16_t iSpeedNeutral;		// = 2048 REMOTE_ADC
-		uint16_t iSteerNeutral;		// = 2048 REMOTE_ADC
-		uint16_t iSpeedMax;				// = 4096 REMOTE_ADC
-		uint16_t iSpeedMin;				// = 0		REMOTE_ADC
-		uint16_t iSteerMax;				// = 4096	REMOTE_ADC
-		uint16_t iSteerMin;				// = 0		REMOTE_ADC
+	typedef struct {
+			uint32_t iVersion;
+			uint16_t wState;
+			uint16_t iSpeedNeutral;		// = 2048 REMOTE_ADC
+			uint16_t iSteerNeutral;		// = 2048 REMOTE_ADC
+			uint16_t iSpeedMax;				// = 4096 REMOTE_ADC
+			uint16_t iSpeedMin;				// = 0		REMOTE_ADC
+			uint16_t iSteerMax;				// = 4096	REMOTE_ADC
+			uint16_t iSteerMin;				// = 0		REMOTE_ADC
+			uint8_t padding[2];  // Pad to 20 bytes for word alignment. added by Deepseek
 	} ConfigData;
 	#pragma pack(pop)
 #endif

--- a/HoverBoardGigaDevice/Inc/defines/defines_2-2-3.h
+++ b/HoverBoardGigaDevice/Inc/defines/defines_2-2-3.h
@@ -1,4 +1,5 @@
 // Gen2.2.3  https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/84
+// a.k.a. SMART-L-V2.0 (used in Andersson 3.1 and Andersson 3.2 with 10 inch wheels)
 
 #ifdef MASTER_OR_SINGLE		// layout 2.2 and 2.7 have buzzer on the slave board.
 	#define HAS_BUZZER
@@ -8,19 +9,20 @@
 #define HALL_B		PA2
 #define HALL_C		PA1
 
-/*
-#define LED_RED			PB3
-#define LED_ORANGE	PA15
-#define LED_GREEN		PA12
-#define UPPER_LED		PA11
+
+//#define LED_RED			PB3
+//#define LED_ORANGE	PA15
+//#define LED_GREEN		PA12 // JW: PB3 in defines_2-2-1.h
+//#define UPPER_LED		PA11 // robo according to "Hoverboard JC2015.7.31.pdf" PA11
 //#define LOWER_LED		P??
 //#define ONBOARD_LED		P??
+//#define CHARGE_STATE PF0 // JW: Charger port is directly connected to battery cable, so probably not possible to detect charger state.
 #define BUZZER		PB1
 
 #define SELF_HOLD		PA4
 #define BUTTON		PA3
 //#define BUTTON_PU		PA3
-*/
+
 
 #define VBATT		PA5
 #define CURRENT_DC		PA7

--- a/HoverBoardGigaDevice/Inc/setup.h
+++ b/HoverBoardGigaDevice/Inc/setup.h
@@ -102,6 +102,5 @@ void USART_Steer_COM_init(void);
 void ConfigReset(void);
 void ConfigWrite(void);
 void ConfigRead(void);
-void confErase(void);
 
 #endif


### PR DESCRIPTION
- Updated to support different flash sizes, see https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/84 
- Updated to support STM32F103 (STM32 only supports to write half word (16 bits) to flash, see ST Reference manual RM00008) 
- Minor updates to ports for board 2.2.3