### PR TITLE
Minor correction for ROS2 master

### DIFF
--- a/HoverBoardGigaDevice/Inc/config.h
+++ b/HoverBoardGigaDevice/Inc/config.h
@@ -83,6 +83,7 @@
 	#if defined(MASTER) || defined(SLAVE)
 		#define MASTERSLAVE_USART		1 	// 	1 is usually PA2/PA3 and the original master-slave 4pin header
 																		//	0 is usually PB6/PB7 and the empty header close to the flash-header
+																		//	2 is usually PB10/PB11 on stm32f103 boards
 	#endif
 	
 	#if defined(REMOTE_UART) || defined(REMOTE_UARTBUS) || defined(REMOTE_CRSF) || defined(REMOTE_ROS2)

--- a/HoverBoardGigaDevice/Src/RemoteROS2.c
+++ b/HoverBoardGigaDevice/Src/RemoteROS2.c
@@ -97,11 +97,11 @@ void RemoteUpdate(void)
 	feedback.wheelL_cnt = modulo32(iOdom, ENCODER_MAX);
 	feedback.left_dc_curr = (int16_t) (currentDC * 100);
 
-#ifdef MASTER_OR_SLAVE
+#ifdef MASTER
 	feedback.speedR_meas = (int16_t) (oDataSlave.realSpeed * 100); // TODO: Need to scale? 100 is just a guess... 
-	feedback.wheelR_cnt = modulo(oDataSlave.iOdom, ENCODER_MAX);
+	feedback.wheelR_cnt = modulo32(oDataSlave.iOdom, ENCODER_MAX);
 	feedback.right_dc_curr = (int16_t) (oDataSlave.currentDC * 100);
-#else
+#else // SINGLE (SLAVE not possible due to ifdef MASTER_OR_SINGLE at top of this file)
 	feedback.speedR_meas = (int16_t) (realSpeed * 100); // Fake both wheels with same speed for single. TODO: Need to scale?
 	feedback.wheelR_cnt = modulo32(iOdom, ENCODER_MAX); // Fake both wheels with same speed for single.
 	feedback.right_dc_curr = 0;


### PR DESCRIPTION
Fix compilation error in ROS2 remote for master variant of firmware.
Also document in config.h that USART2 PB10/PB11 is also possible as MASTERSLAVE_USART on gd32f103 target.