### PR TITLE
Update for PID tuning

### DIFF
--- a/HoverBoardGigaDevice/Inc/RemoteROS2.h
+++ b/HoverBoardGigaDevice/Inc/RemoteROS2.h
@@ -1,6 +1,8 @@
 #ifndef REMOTE_ROS2_H
 #define REMOTE_ROS2_H
 
+#include <stdint.h>
+
 #define STAND_STILL_THRESHOLD 10
 
 #define REMOTE_BAUD 19200
@@ -9,7 +11,7 @@
 
 #define LOST_CONNECTION_STOP_MILLIS 500		// set speed to 0 when 500 ms no command received
 
-//#undef PILOT_DEFAULT
-//void 	Pilot(int16_t* pPwmMaster, int16_t* pPwmSlave);
+#undef PILOT_DEFAULT
+void 	Pilot(int16_t* pPwmMaster, int16_t* pPwmSlave);
 
 #endif // REMOTE_ROS2_H

--- a/HoverBoardGigaDevice/Inc/defines/defines_2-2-3.h
+++ b/HoverBoardGigaDevice/Inc/defines/defines_2-2-3.h
@@ -1,6 +1,8 @@
 // Gen2.2.3  https://github.com/RoboDurden/Hoverboard-Firmware-Hack-Gen2.x/issues/84
 // a.k.a. SMART-L-V2.0 (used in Andersson 3.1 and Andersson 3.2 with 10 inch wheels)
 
+#define STM32F103 // Configure system clock to 64 MHz (maximum supported with High Speed Internal (HSI) oscilator as clock source for STM32F103)
+
 #ifdef MASTER_OR_SINGLE		// layout 2.2 and 2.7 have buzzer on the slave board.
 	#define HAS_BUZZER
 #endif

--- a/HoverBoardGigaDevice/Src/it.c
+++ b/HoverBoardGigaDevice/Src/it.c
@@ -121,8 +121,8 @@ void TIMEOUT_IrqHandler(void)
 // -> pwm of timer0 running with 16kHz -> interrupt every 31,25us
 //----------------------------------------------------------------------------
 extern uint32_t steerCounter;								// Steer counter for setting update rate
-uint32_t iPwmTicks = 0, iPwmTicks0 = 0, iPwmCounter = 0, iPwmTime=0, iPwmRate=0;
-uint32_t iAdcTicks = 0, iAdcTicks0 = 0, iAdcCounter = 0, iAdcTime=0, iAdcRate=0;
+uint32_t iPwmCounter = 0, iPwmTime=0, iPwmRate=0;
+uint32_t iAdcCounter = 0, iAdcTime=0, iAdcRate=0;
 #define COUNT_Irqs 1000
 
 //void TIMER0_UP_IRQHandler(void)	//JMA must match the name in startup_gd32f10x_hd.s
@@ -164,15 +164,6 @@ void TARGET_TIMER0_BRK_UP_TRG_COM_IRQHandler(void)
 #endif
 void TARGET_DMA_Channel0_IRQHandler(void)
 {
-/*
-	
-	if (COUNT_Irqs == ++iAdcCounter)
-	{
-		iAdcTicks = msTicks - iAdcTicks0;
-		iAdcTicks0 = msTicks;
-		iAdcCounter = 0;
-	}
-	*/
 
 	if (TARGET_dma_interrupt_flag_get(DMA_CH0, DMA_INT_FLAG_FTF))
 	{

--- a/HoverBoardGigaDevice/Src/setup.c
+++ b/HoverBoardGigaDevice/Src/setup.c
@@ -126,7 +126,7 @@ void TimeoutTimer_init(void)
 	timeoutTimer_paramter_struct.counterdirection 	= TIMER_COUNTER_UP;
 	timeoutTimer_paramter_struct.prescaler 					= 0;
 	timeoutTimer_paramter_struct.alignedmode 				= TIMER_COUNTER_CENTER_DOWN;
-	timeoutTimer_paramter_struct.period							= 72000000 / 2 / TIMEOUT_FREQ;
+	timeoutTimer_paramter_struct.period							= SystemCoreClock / 2 / TIMEOUT_FREQ;
 	timeoutTimer_paramter_struct.clockdivision 			= TIMER_CKDIV_DIV1;
 	timeoutTimer_paramter_struct.repetitioncounter 	= 0;
 	timer_auto_reload_shadow_disable(TIMER_TIMEOUT);


### PR DESCRIPTION
Updates to be able to tune PID parameters with TestSpeed.ino and RemoteROS2 without having to recompile firmware to change parameters.

Added RemoteROS2 support to TestSpeed.ino, including support to tune PID parameter with PidConfig message.

RemoteROS2 support for configuring PID parameters at runtime using PidConfig message (if REMOTE_ROS2_PID_TUNING is defined)

Minor improvements:
* Fixed iOdom-iOdomLast overflow warning in revs32 and torque32 calculations.
* Reset revs32_reg=0 and torque32_reg=0 when speed is considered 0 (speedCounterSlow >= 4000).
* Comments/Documentation about speed estimates (revs32, iOdom etc).