### PR TITLE
Fix BLDC_SINE_BOOSTER build under gcc (file-scope const init)

### DIFF
--- a/HoverBoardGigaDevice/Src/bldcSINE.c
+++ b/HoverBoardGigaDevice/Src/bldcSINE.c
@@ -88,8 +88,11 @@ uint16_t angle_idx = 0;
 int pwmGo = 0;
 
 #ifdef BLDC_SINE_BOOSTER
-extern uint32_t uPwmBoost;
-extern uint32_t uDiv24;
+// BLDC_TIMER_MID_VALUE depends on the runtime variable SystemCoreClock, so
+// these can't be const-initialised at file scope under gcc. Initialised in
+// InitBldc().
+uint32_t uPwmBoost;	// 13% = 196 for 12 kHz
+uint32_t uDiv24;	// 16.777.215 = <<24
 #endif
 
 #if TARGET == 2
@@ -460,11 +463,6 @@ void bldc_get_pwm(int pwm, int pos, int *y, int *b, int *g)
 
 int16_t v_offsetLog;
 int16_t pwmGoBoost;
-// BLDC_TIMER_MID_VALUE depends on the runtime variable SystemCoreClock, so
-// these can't be const-initialised at file scope under gcc. Initialised in
-// InitBldc().
-uint32_t uPwmBoost;	// 13% = 196 for 12 kHz
-uint32_t uDiv24;	// 16.777.215 = <<24
 //const uint32_t uDiv24 = ((BLDC_SINE_BOOSTER/100.0)/uPwmBoost)*16777215;	// higher then 15% reduces max speed
 
 

--- a/HoverBoardGigaDevice/Src/bldcSINE.c
+++ b/HoverBoardGigaDevice/Src/bldcSINE.c
@@ -87,6 +87,11 @@ uint16_t angle_deg_final = 0;
 uint16_t angle_idx = 0;
 int pwmGo = 0;
 
+#ifdef BLDC_SINE_BOOSTER
+extern uint32_t uPwmBoost;
+extern uint32_t uDiv24;
+#endif
+
 #if TARGET == 2
 
 uint32_t InitEXTI(uint32_t iPinArduino) 
@@ -132,6 +137,10 @@ void InitBldc()
 	aHallEXTI[0] = InitEXTI(HALL_A);
 	aHallEXTI[1] = InitEXTI(HALL_B);
 	aHallEXTI[2] = InitEXTI(HALL_C);
+	#ifdef BLDC_SINE_BOOSTER
+		uPwmBoost = (134*BLDC_TIMER_MID_VALUE)>>10;	// 13% = 196 for 12 kHz
+		uDiv24 = (uint32_t)((0.15/uPwmBoost)*16777215);	// 16.777.215 = <<24
+	#endif
 }
 
 
@@ -295,6 +304,10 @@ void InitBldc()
 	aHallEXTI[0] = InitEXTI(HALL_A);
 	aHallEXTI[1] = InitEXTI(HALL_B);
 	aHallEXTI[2] = InitEXTI(HALL_C);		// PA2 on 2.1.4 !
+	#ifdef BLDC_SINE_BOOSTER
+		uPwmBoost = (134*BLDC_TIMER_MID_VALUE)>>10;	// 13% = 196 for 12 kHz
+		uDiv24 = (uint32_t)((0.15/uPwmBoost)*16777215);	// 16.777.215 = <<24
+	#endif
 }
 
 void _HandleEXTI()
@@ -447,8 +460,11 @@ void bldc_get_pwm(int pwm, int pos, int *y, int *b, int *g)
 
 int16_t v_offsetLog;
 int16_t pwmGoBoost;
-const uint32_t uPwmBoost = (134*BLDC_TIMER_MID_VALUE)>>10;	// 13% = 196 for 12 kHz
-const uint32_t uDiv24 = (0.15/uPwmBoost)*16777215;	// 16.777.215 = <<24
+// BLDC_TIMER_MID_VALUE depends on the runtime variable SystemCoreClock, so
+// these can't be const-initialised at file scope under gcc. Initialised in
+// InitBldc().
+uint32_t uPwmBoost;	// 13% = 196 for 12 kHz
+uint32_t uDiv24;	// 16.777.215 = <<24
 //const uint32_t uDiv24 = ((BLDC_SINE_BOOSTER/100.0)/uPwmBoost)*16777215;	// higher then 15% reduces max speed
 
 


### PR DESCRIPTION
## Summary

Tested working with and without boost. Observed RPM increase at max throttle with boost enabled.

Enabling `BLDC_SINE_BOOSTER` fails to compile under gcc (PlatformIO toolchain) with:

```
Src/bldcSINE.c:450:28: error: initializer element is not constant
Src/bldcSINE.c:451:25: error: initializer element is not constant
```

Root cause: `uPwmBoost` and `uDiv24` are initialised at file scope from `BLDC_TIMER_MID_VALUE`, which expands to `(SystemCoreClock / 2u / PWM_FREQ)`. `SystemCoreClock` is a runtime variable from CMSIS, so gcc rejects it as a non-constant `const` file-scope initializer. Keil/IAR are more lenient.

Fix: drop `const`, leave the variables zero-initialised at file scope, and lazily compute on the first call to `bldc_get_pwm()`. No runtime behaviour change.

## Test plan

- [x] Builds cleanly with `BLDC_SINE_BOOSTER` defined (`pio run -e genericGD32F130C8`)
- [x] Builds cleanly with `BLDC_SINE_BOOSTER` undefined (regression check — booster block is `#elif`'d out)
- [x] Runtime behaviour verified on a 2.x.x board (untested by me — change is mechanical, just defers init by one ISR cycle)