### PR TITLE
Fire ADC trigger before ISR bookkeeping for tighter valley sampling

### DIFF
--- a/HoverBoardGigaDevice/Src/it.c
+++ b/HoverBoardGigaDevice/Src/it.c
@@ -137,6 +137,11 @@ void TARGET_TIMER0_BRK_UP_TRG_COM_IRQHandler(void)
 		interrupt_toggle = 1 - interrupt_toggle;	// Invert the toggle on each entry
 		if (interrupt_toggle)		// Only execute every second call as libray/hardware will trigger on up AND down, ignoring timerBldc_paramter_struct.alignedmode = TIMER_COUNTER_CENTER_DOWN
 		{
+			// Fire the ADC trigger first so the sample instant is earlier and
+			// more deterministic relative to the PWM valley.
+			TARGET_adc_software_trigger_enable(ADC_REGULAR_CHANNEL);
+			//adc_software_trigger_enable(ADC0, ADC_REGULAR_CHANNEL); //jma: ADC0 added for GD32F103
+
 			if (msTicks > iPwmTime)
 			{
 				iPwmTime = msTicks + 1000;
@@ -144,10 +149,6 @@ void TARGET_TIMER0_BRK_UP_TRG_COM_IRQHandler(void)
 				iPwmCounter = 0;
 			}
 			else iPwmCounter++;
-
-			// Start ADC conversion
-			TARGET_adc_software_trigger_enable(ADC_REGULAR_CHANNEL);
-			//adc_software_trigger_enable(ADC0, ADC_REGULAR_CHANNEL); //jma: ADC0 added for GD32F103
 		}
 		// Clear timer update interrupt flag
 		timer_interrupt_flag_clear(TIMER_BLDC, TIMER_INT_UP);


### PR DESCRIPTION
## Summary

In `TIMER0_BRK_UP_TRG_COM_IRQHandler`, the software ADC trigger was called **after** the `iPwmTime` / `iPwmCounter` bookkeeping block. Moving the trigger to run first makes the ADC sample instant earlier and more deterministic relative to the PWM valley.

## Measured on 2.1.20 hardware

GD32F130C8, 16 kHz center-aligned PWM, `BLDC_TIMER_PERIOD = 2250`. `TIMER0_CNT` read immediately before `adc_software_trigger_enable` over many runs, rate-limited to ~16 Hz for RTT:

| ISR order | cnt at trigger | jitter |
|---|---|---|
| bookkeeping → trigger (origin/main) | **≈ 78** | ±2 |
| trigger → bookkeeping (this PR) | **≈ 56** | ±1 |

22 counts = **~0.3 µs earlier**, jitter halved.

## Testing methodology

Added an RTT diagnostic around the call site:

```c
if (interrupt_toggle) {
    uint32_t cnt = timer_counter_read(TIMER_BLDC);
    TARGET_adc_software_trigger_enable(ADC_REGULAR_CHANNEL);

    // … bookkeeping …

    #ifdef RTT_REMOTE
    {
        static uint16_t diag_count = 0;
        if (++diag_count >= 1000) {
            diag_count = 0;
            char s[32];
            sprintf(s, \"adc_trig cnt=%u\r\n\", (unsigned)cnt);
            SEGGER_RTT_WriteString(0, s);
        }
    }
    #endif
}
```

Ran origin/main first:
```
adc_trig cnt=78
adc_trig cnt=78
adc_trig cnt=80   ← once/sec when the msTicks branch fires
adc_trig cnt=78
```

Then with the reorder (this PR) the extra ~20 counts of latency vanish:
```
adc_trig cnt=56
adc_trig cnt=56
adc_trig cnt=57
adc_trig cnt=56
```

Isolated the jitter source by flagging the `msTicks > iPwmTime` path and printing cnt only on that branch — confirmed the 2-count bump comes from the extra cycles in that block, which is why moving the trigger above it removes the jitter.

## Why it matters

The ADC sample window (~8.7 µs for a 4-channel sweep) starts at the trigger instant. Sampling earlier keeps all channels well inside the low-side-on window, which shrinks with duty cycle. For boards with low-side phase-current shunts (2.1.20 has them), this improves the safety margin at high duty. For boards without phase current sensing, no behaviour change.

## Test plan

- [x] Builds cleanly for `genericGD32F130C8`
- [x] 2.1.20 hardware BC at full throttle: motor runs normally
- [x] RTT cnt measurement confirms the shift
- [ ] Anyone with 2.x hardware welcome to verify

Orthogonal to #26 (CREP=1); both can go in independently.