### PR TITLE
F103 bring-up fixes: pinModeAF, JTAG disable, layout 2-2-20

### DIFF
--- a/HoverBoardGigaDevice/Inc/defines/defines_2-2-20.h
+++ b/HoverBoardGigaDevice/Inc/defines/defines_2-2-20.h
@@ -1,0 +1,55 @@
+#ifndef DEFINES_2_2_20_H
+#define DEFINES_2_2_20_H
+
+#define LED_GREEN PB3
+#define LED_ORANGE PA15
+#define LED_RED PB4
+#define UPPER_LED PB2
+#define LOWER_LED PB5
+
+#define PHOTO_L PC15
+#define PHOTO_R PA11
+
+
+#define HALL_A PC13
+#define HALL_B PA1
+#define HALL_C PC14
+
+#define BUZZER PB9
+
+#define VBATT PA4
+#define ADC_BATTERY_VOLT      0.02507  	// V_Batt to V_BattMeasure = factor 30: ( (ADC-Data/4095) *3,3V *30 )
+
+//#define CURRENT_DC P??		// no DC bus shunt on this board
+// Per-phase current sensing: 2x R004 (4mΩ) shunt resistors on low-side FETs,
+// amplified by dual op-amp (~20x gain). No shunt on the third phase.
+#define PHASE_CURRENT_A	PB0		// 4mΩ shunt + op-amp on phase A low-side
+#define PHASE_CURRENT_B	PA0		// 4mΩ shunt + op-amp on phase B low-side
+
+#define SELF_HOLD	PB12
+#define BUTTON PA12
+
+// Brushless Control DC (BLDC) defines
+#define BLDC_GH PA10		// green	, Tommyboi2001 all bldc pins same as 2.0
+#define BLDC_GL PB15		
+#define BLDC_BH PA9			// blue
+#define BLDC_BL PB14		
+#define BLDC_YH PA8			// yellow
+#define BLDC_YL PB13		
+#define TIMER_BLDC_PULLUP	GPIO_PUPD_NONE	// robo: not sure if some boards indeed nned GPIO_PUPD_PULLUP like 2.2 or 2.3
+
+// GD32F103 USART0 default pins: PA9/PA10. PB6/PB7 available via remap (see setup.c).
+#define USART0_TX	PB6	// using AFIO_PCF0 USART0_REMAP -> PB6/PB7
+#define USART0_RX	PB7
+
+// GD32F103 USART1 pins: PA2/PA3 (master-slave 4-pin header on this board).
+#define USART1_TX		PA2
+#define USART1_RX		PA3
+
+//#define MPU_6050		// Gemini tried for clones..
+//#define MPU_6050old	// disabled on F103 — i2c.c lacks a PB6/PB7 path for TARGET=2
+//#define I2C_PB6PB7	// IMU
+
+
+
+#endif

--- a/HoverBoardGigaDevice/Inc/target.h
+++ b/HoverBoardGigaDevice/Inc/target.h
@@ -167,7 +167,7 @@
 
 	#define pinModeAF(pin, AF, pullUpDown,speed) \
 	{\
-		 gpio_init(pin&0xffffff00U, pullUpDown, GPIO_OSPEED_50MHZ, BIT(pin&0xfU)); 	\
+		 gpio_init(pin&0xffffff00U, GPIO_MODE_AF_PP, speed, BIT(pin&0xfU)); 	\
 	}
 
 	

--- a/HoverBoardGigaDevice/Src/setup.c
+++ b/HoverBoardGigaDevice/Src/setup.c
@@ -151,7 +151,12 @@ void GPIO_init(void)
 	rcu_periph_clock_enable(RCU_GPIOC);
 	rcu_periph_clock_enable(RCU_GPIOF);
 
-	
+	#ifdef GD32F103
+		// Disable JTAG, keep SWD. Frees PA15/PB3/PB4 (JTDI/JTDO/NJTRST) for GPIO use.
+		rcu_periph_clock_enable(RCU_AF);
+		gpio_pin_remap_config(GPIO_SWJ_SWDPENABLE_REMAP, ENABLE);
+	#endif
+
 	#ifdef TIMER_BLDC_EMERGENCY_SHUTDOWN
 		// Init emergency shutdown pin
 		pinModeAF(TIMER_BLDC_EMERGENCY_SHUTDOWN,AF_TIMER0_BRKIN,GPIO_PUPD_NONE,GPIO_OSPEED_50MHZ)


### PR DESCRIPTION


https://github.com/user-attachments/assets/63b72a6e-d507-4abf-86e0-f363dd6ea40c




## Summary
Three small fixes that together let a GD32F103 board (with the same PCB layout as 2-1-20) build and run from this codebase. Discovered while bringing up an F103 hoverboard board on the bench.

- **Fix `pinModeAF` macro on F103.** It was passing `pullUpDown` as the gpio mode and dropping the AF parameter, so the BLDC PWM pins ended up as `GPIO_MODE_IN_FLOATING`. TIMER0 was generating PWM but it never reached the FETs (motor silent, supply current ~50 mA at 27 V).
- **Disable JTAG on F103.** PA15/PB3/PB4 are reserved for SWJ-DP after reset. All F103 layout files put LEDs on those pins. Symptom was red+orange LEDs stuck on — JTDI/NJTRST internal pull-ups overriding GPIO writes. Switching to "JTAG-DP disabled, SW-DP enabled" frees them; SWD debug still works.
- **Add `defines_2-2-20.h`.** Layout file for boards with the 2-1-20 PCB layout but F103 silicon. IMU defines are off because `i2c.c` has no `I2C_PB6PB7` path for TARGET=2.

Pairs with #29 (phase-current naming alignment).

## Test plan
- [x] Bench-tested on a 2-1-20-layout board with GD32F103: motor zigzags correctly under `BLDC_BC + REMOTE_DUMMY` after these fixes.
- [x] Bench-tested LEDs: all three follow hall sensors with `TEST_HALL2LED`.
- [ ] F130 / E230 unaffected (changes are guarded by `#ifdef GD32F103` or live in the F103 branch of `target.h`).