### PR TITLE
GD32F103: fix pinModeAF macro to actually set AF mode

### DIFF
--- a/HoverBoardGigaDevice/Inc/target.h
+++ b/HoverBoardGigaDevice/Inc/target.h
@@ -167,7 +167,7 @@
 
 	#define pinModeAF(pin, AF, pullUpDown,speed) \
 	{\
-		 gpio_init(pin&0xffffff00U, pullUpDown, GPIO_OSPEED_50MHZ, BIT(pin&0xfU)); 	\
+		 gpio_init(pin&0xffffff00U, GPIO_MODE_AF_PP, speed, BIT(pin&0xfU)); 	\
 	}
 
 	


### PR DESCRIPTION
## Summary

Fix the `pinModeAF` macro on `GD32F103`, which currently configures every pin
that uses it as a floating input rather than as the requested alternate function.
The TIMER0 PWM pins on every F103 board layout are affected, so motors don't
spin out of the box.

## The bug

In `Inc/target.h` the F103 path of `pinModeAF` was:

```c
#define pinModeAF(pin, AF, pullUpDown,speed) \
{\
     gpio_init(pin&0xffffff00U, pullUpDown, GPIO_OSPEED_50MHZ, BIT(pin&0xfU)); \
}
```

It passes `pullUpDown` as the `mode` argument to `gpio_init` and never writes
the requested AF mode. Because `target.h` aliases `GPIO_PUPD_NONE` →
`GPIO_MODE_IN_FLOATING`, calls like

```c
pinModeAF(BLDC_GH, AF_TIMER0_BLDC, GPIO_PUPD_NONE, GPIO_OSPEED_2MHZ);
```

end up configuring the pin as a floating input.

## The fix

```c
#define pinModeAF(pin, AF, pullUpDown,speed) \
{\
     gpio_init(pin&0xffffff00U, GPIO_MODE_AF_PP, speed, BIT(pin&0xfU)); \
}
```

Use `GPIO_MODE_AF_PP` and the requested speed. F1x0 / E230 paths are
unchanged.

`pullUpDown` is intentionally not propagated. F103 uses v1 GPIO (CRL/CRH)
where pull-up/down isn't a register field for AF outputs — it only exists
when the pin is in input mode. Confirmed by the GD32F10x User Manual §7.3.7
("The weak pull-up and pull-down resistors could be chosen when input.").

## Register evidence on real F103 silicon

Bench dump on a freshly-flashed F103 board running upstream main, **before**
the fix, with TIMER0 already configured and `MOE=1`:

```
GPIOA CRH = 0x38848444
  PA8 = 0x4 → MODE=00, CNF=01 → floating input
  PA9 = 0x4 → floating input
  PA10 = 0x4 → floating input

GPIOB CRH = 0x44444434
  PB13 = 0x4 → floating input
  PB14 = 0x4 → floating input
  PB15 = 0x4 → floating input

TIM1 CCER = 0x00000ddd  (CC1E/CC1NE/CC2E/CC2NE/CC3E/CC3NE all set)
TIM1 BDTR = 0x0000c83c  (MOE=1, AOE=1, dead-time = 60 cycles)
```

So the timer is happily generating six channels of complementary PWM into pins
that are floating inputs. Motor stays silent, supply pulling ~50 mA at 27 V.

**After** the fix:

```
GPIOA CRH = 0x38848aaa
  PA8/9/10 = 0xa → MODE=10 (2 MHz), CNF=10 → AF push-pull
GPIOB CRH = 0xaaa44434
  PB13/14/15 = 0xa → AF push-pull
```

Motor spins under joystick control on `defines_2-2-20.h` LAYOUT 20.

## Test plan

- [x] Bench-tested on a GD32F103 board with `defines_2-2-20.h` LAYOUT 20 in
  `BLDC_BC + REMOTE_UART` mode: motor responds to joystick input after this
  fix; doesn't without it.
- [x] Register-level verification of GPIO CRH / TIM1 CCER / TIM1 BDTR via
  `openocd` `mdw` before and after.
- [ ] F130 / E230 paths unchanged — both live in unrelated `#elif` branches
  in `Inc/target.h`.

## Notes for review

This PR replaces and supersedes the pinModeAF half of #31 (the SWJ-remap half
of #31 was already adopted in `bbce8bf f103 bug resolved:
GPIO_SWJ_SWDPENABLE_REMAP`).

Codex flagged a follow-up concern in #31's review about the
`TIMER_BLDC_EMERGENCY_SHUTDOWN` (BRK input) pin: with `pinModeAF` now forcing
AF push-pull, the BRK call site would set the pin as a driven output instead
of an input. That's a real concern but only matters on the one F103 layout
that defines `TIMER_BLDC_EMERGENCY_SHUTDOWN` (`defines_2-2-7.h`). All other
F103 layouts leave that `#ifdef` out, so the BRK call site doesn't compile in
and the change in this PR has no effect on it. A separate PR can address the
BRK call-site fix if desired — it's an independent change at the call site.
