### PR TITLE
Fix speed estimate in RemoteROS2

### DIFF
--- a/HoverBoardGigaDevice/Src/RemoteROS2.c
+++ b/HoverBoardGigaDevice/Src/RemoteROS2.c
@@ -96,6 +96,12 @@ typedef struct {
 uint32_t iTimeLastRx = 0;
 uint32_t iTimeNextTx = 0;
 
+// For speed feedback in RemoteUpdate(),
+// SPEED_AsRevsPerSec needs to be defined in config.h
+#ifndef SPEED_AsRevsPerSec
+  #error "RemoteROS2 assumes SPEED_AsRevsPerSec is defined"
+#endif
+
 // Send frame to steer device
 // Called from main() every 2*DELAY_IN_MAIN_LOOP = 10ms
 void RemoteUpdate(void)
@@ -146,12 +152,12 @@ void RemoteUpdate(void)
 	feedback.cmdLed = revs32;             // Not used by ROS2 hoverboard-driver
 	feedback.batVoltage = (int16_t) (batteryVoltage * 100); // Unit: 0.01 V
 	feedback.boardTemp = 250; // Dummy value (250 => 25 degrees)
-	feedback.speedL_meas = (int16_t) (realSpeed * 1000); // TODO: Base on revs32/revs32x instead! 1000 is just a random scale-factor. Only published by ROS2 hoverboard_driver for logging...
+	feedback.speedL_meas = (int16_t) (realSpeed * 60.0f); // realSpeed is revs/s (when SPEED_AsRevsPerSec is defined), so multiply by 60 for RPM
 	feedback.wheelL_cnt = modulo32(iOdom, ENCODER_MAX);
 	feedback.left_dc_curr = (int16_t) (currentDC * 100);
 
 #ifdef MASTER
-	feedback.speedR_meas = (int16_t) (oDataSlave.realSpeed * 1000); // TODO: Base on revs32/revs32x instead! 1000 is just a random scale-factor. Only published by ROS2 hoverboard_driver for logging...
+	feedback.speedR_meas = (int16_t) (-oDataSlave.realSpeed * 60.0f); // realSpeed is revs/s (when SPEED_AsRevsPerSec is defined), so multiply by 60 for RPM. Negate sign, see wheelR_cnt below.
 	feedback.wheelR_cnt = modulo32(-oDataSlave.iOdom, ENCODER_MAX); // Negate sign on slave iOdom. Since master and slave are identical, they count in opposite direction when moving straight.
 	feedback.right_dc_curr = (int16_t) (oDataSlave.currentDC * 100);
 #else // SINGLE (SLAVE not possible due to ifdef MASTER_OR_SINGLE at top of this file)

--- a/HoverBoardGigaDevice/Src/bldc.c
+++ b/HoverBoardGigaDevice/Src/bldc.c
@@ -339,7 +339,7 @@ void CalculateBLDC(void)
 		#define RANK_realSpeed32 10 	// Calculate low-pass filter for pwm value
 		realSpeed32_reg = realSpeed32_reg - (realSpeed32_reg >> RANK_realSpeed32) + revs32;
 	
-		realSpeed	= (realSpeed32_reg >> RANK_realSpeed32) / 1024.0;
+		realSpeed	= (realSpeed32_reg >> RANK_realSpeed32) / (float)(1 << REVS32_SHIFT);
 	#else
 		// Every time position reaches value 1, one (electrical 360�) round = 24� mechanical angle is performed (rising edge)
 		if (lastPos != 1 && pos == 1)


### PR DESCRIPTION
Use SPEED_AsRevsPerSec for RemoteROS2 and fix conversion to RPM in SerialFeedback.
Also fix bug in bldc.c for calculating realSpeed from revs32 when SPEED_AsRevsPerSec is enabled.

When testing on my physical robot, I found that speed estimates was wrong with a factor of 4. I think I found a bug in the calculation of realSpeed when SPEED_AsRevsPerSec is enabled. Then realSpeed is based on revs32 and needs to be scaled by (1 << REVS32_SHIFT) = 4096. Previously it was hardcoded to 1024 and thus the factor 4 difference in my testing.